### PR TITLE
New: Codify AwsVpc

### DIFF
--- a/lib/geoengineer/resources/aws_vpc.rb
+++ b/lib/geoengineer/resources/aws_vpc.rb
@@ -1,0 +1,24 @@
+########################################################################
+# AwsVpc is the +aws_vpc+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/vpc.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsVpc < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:cidr_block]) }
+  validate -> { validate_has_tag(:Name) }
+  validate -> { validate_cidr_block(self.cidr_block) if self.cidr_block }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
+
+  def self._fetch_remote_resources
+    AwsClients.ec2.describe_vpcs['vpcs'].map(&:to_h).map do |vpc|
+      vpc.merge(
+        {
+          _terraform_id: vpc[:vpc_id],
+          _geo_id: vpc[:tags] ? vpc[:tags].find { |tag| tag[:key] == "Name" }[:value] : nil
+        }
+      )
+    end
+  end
+end

--- a/spec/resources/aws_vpc_spec.rb
+++ b/spec/resources/aws_vpc_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../spec_helper'
+
+describe("GeoEngineer::Resources::AwsVpc") do
+  common_resource_tests(GeoEngineer::Resources::AwsVpc, 'aws_vpc')
+  name_tag_geo_id_tests(GeoEngineer::Resources::AwsVpc)
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      ec2 = AwsClients.ec2
+      stub = ec2.stub_data(
+        :describe_vpcs,
+        {
+          vpcs: [
+            { vpc_id: 'name1', cidr_block: "10.120.0.0/24", tags: [{ key: 'Name', value: 'one' }] },
+            { vpc_id: 'name2', cidr_block: "10.120.1.0/24", tags: [{ key: 'Name', value: 'two' }] }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_vpcs, stub)
+      remote_resources = GeoEngineer::Resources::AwsVpc._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
This adds the Aws VPC resource to GeoEngineer, so that we can begin to
codify our existing VPC's.

How has it been tested:
=======================
Added a couple specs.

@mentions:
==========
@grahamjenson