### PR TITLE
New: Add route_table_associations to Geo

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+require './lib/geoengineer'

--- a/lib/geoengineer/resources/aws_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_route_table_association.rb
@@ -1,0 +1,29 @@
+########################################################################
+# AwsRouteTableAssociation is the +aws_route_table_association+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/route_table_association.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsRouteTableAssociation < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:subnet_id, :route_table_id]) }
+
+  after :initialize, -> { _terraform_id -> { "#{zone_id}_#{name}_#{type}" } }
+  after :initialize, -> { _geo_id -> { "#{subnet_id}|#{route_table_id}" } }
+
+  def self._fetch_remote_resources
+    AwsClients
+      .ec2
+      .describe_route_tables['route_tables']
+      .map(&:to_h)
+      .map { |route_table| route_table[:associations] }
+      .flatten
+      .compact
+      .map do |association|
+        association.merge(
+          {
+            _terraform_id: association[:route_table_association_id],
+            _geo_id: "#{association[:subnet_id]}|#{association[:route_table_id]}"
+          }
+        )
+      end
+  end
+end

--- a/lib/geoengineer/resources/aws_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_route_table_association.rb
@@ -7,7 +7,7 @@ class GeoEngineer::Resources::AwsRouteTableAssociation < GeoEngineer::Resource
   validate -> { validate_required_attributes([:subnet_id, :route_table_id]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{subnet_id}|#{route_table_id}" } }
+  after :initialize, -> { _geo_id -> { "#{subnet_id}::#{route_table_id}" } }
 
   def self._fetch_remote_resources
     AwsClients

--- a/lib/geoengineer/resources/aws_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_route_table_association.rb
@@ -6,7 +6,7 @@
 class GeoEngineer::Resources::AwsRouteTableAssociation < GeoEngineer::Resource
   validate -> { validate_required_attributes([:subnet_id, :route_table_id]) }
 
-  after :initialize, -> { _terraform_id -> { "#{zone_id}_#{name}_#{type}" } }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{subnet_id}|#{route_table_id}" } }
 
   def self._fetch_remote_resources

--- a/spec/resources/aws_route_table_association_spec.rb
+++ b/spec/resources/aws_route_table_association_spec.rb
@@ -1,0 +1,40 @@
+require_relative '../spec_helper'
+
+describe("GeoEngineer::Resources::AwsRouteTableAssociation") do
+  common_resource_tests(
+    GeoEngineer::Resources::AwsRouteTableAssociation,
+    'aws_route_table_association'
+  )
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      ec2 = AwsClients.ec2
+      stub = ec2.stub_data(
+        :describe_route_tables,
+        {
+          route_tables: [
+            {
+              route_table_id: 'name1',
+              vpc_id: "1",
+              tags: [{ key: 'Name', value: 'one' }],
+              associations: [
+                { route_table_association_id: '1', subnet_id: 's-1', route_table_id: 'r-1' }
+              ]
+            },
+            {
+              route_table_id: 'name2',
+              vpc_id: "1",
+              tags: [{ key: 'Name', value: 'two' }],
+              associations: [
+                { route_table_association_id: '2', subnet_id: 's-2', route_table_id: 'r-2' }
+              ]
+            }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_route_tables, stub)
+      remote_resources = GeoEngineer::Resources::AwsRouteTableAssociation._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end

--- a/spec/resources/aws_route_table_association_spec.rb
+++ b/spec/resources/aws_route_table_association_spec.rb
@@ -7,7 +7,7 @@ describe("GeoEngineer::Resources::AwsRouteTableAssociation") do
   )
 
   describe "#_fetch_remote_resources" do
-    it 'should create list of hashes from returned AWS SDK' do
+    before do
       ec2 = AwsClients.ec2
       stub = ec2.stub_data(
         :describe_route_tables,
@@ -33,6 +33,13 @@ describe("GeoEngineer::Resources::AwsRouteTableAssociation") do
         }
       )
       ec2.stub_responses(:describe_route_tables, stub)
+    end
+
+    after do
+      ec2.stub_responses(:describe_route_tables, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
       remote_resources = GeoEngineer::Resources::AwsRouteTableAssociation._fetch_remote_resources
       expect(remote_resources.length).to eq(2)
     end

--- a/spec/resources/aws_route_table_association_spec.rb
+++ b/spec/resources/aws_route_table_association_spec.rb
@@ -7,8 +7,8 @@ describe("GeoEngineer::Resources::AwsRouteTableAssociation") do
   )
 
   describe "#_fetch_remote_resources" do
+    let(:ec2) { AwsClients.ec2 }
     before do
-      ec2 = AwsClients.ec2
       stub = ec2.stub_data(
         :describe_route_tables,
         {


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Adding the ability to codify route_table_associations to Geo.

One thing to note here is that since route table associations don't have
the ability to add tags, the Geo ID is the concatenation of the 2
required attributes for a route table association: the subnet ID and the
route table ID. I concatenated them with a `|` so that it was a bit more
human readable (as both the subnet ID and route table ID use `-` in
their ID's).

Also added a barebones `.irbrc` file that simply requires
`./lib/geoengineer`. This allows you to:
```
bundle exec irb
```
And immediately start using the methods and classes defined in Geo.

How has it been tested:
=======================
Added some tests.

@mentions:
==========
@grahamjenson
@lukedemi