### PR TITLE
New: Add Aws Vpc DHCP Options Set

### DIFF
--- a/lib/geoengineer/resources/aws_dhcp_options_set.rb
+++ b/lib/geoengineer/resources/aws_dhcp_options_set.rb
@@ -1,0 +1,29 @@
+########################################################################
+# AwsVpcDhcpOptions is the +aws_vpc_dhcp_options+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/vpc_dhcp_options.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsVpcDhcpOptions < GeoEngineer::Resource
+  validate -> { validate_has_tag(:Name) }
+  validate -> {
+    validate_at_least_one_present(
+      %i(
+        domain_name domain_name_servers ntp_servers netbios_name_servers netbios_node_type
+      )
+    )
+  }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
+
+  def self._fetch_remote_resources
+    AwsClients.ec2.describe_dhcp_options['dhcp_options'].map(&:to_h).map do |options|
+      options.merge(
+        {
+          _terraform_id: options[:dhcp_options_id],
+          _geo_id: options[:tags].find { |tag| tag[:key] == "Name" }[:value]
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/utils/has_validations.rb
+++ b/lib/geoengineer/utils/has_validations.rb
@@ -54,4 +54,20 @@ module HasValidations
   rescue NetAddr::ValidationError
     return [nil, "Bad cidr block \"#{cidr_block}\" #{for_resource}"]
   end
+
+  # Validates that at least one of the specified attributes is present
+  def validate_at_least_one_present(attributes)
+    errs = []
+    present = attributes.select { |attribute| !self[attribute].nil? }.count
+    errs << "At least one of #{attributes.join(', ')} must be defined" unless present.positive?
+    errs
+  end
+
+  # Validates that ONLY one of the specified attributes is present
+  def validate_only_one_present(attributes)
+    errs = []
+    present = attributes.select { |attribute| !self[attribute].nil? }.count
+    errs << "Only one of #{attributes.join(', ')} can be defined" unless present == 1
+    errs
+  end
 end

--- a/spec/resources/aws_vpc_dhcp_options_set.rb
+++ b/spec/resources/aws_vpc_dhcp_options_set.rb
@@ -1,0 +1,24 @@
+require_relative '../spec_helper'
+
+describe("GeoEngineer::Resources::AwsVpcDhcpOption") do
+  common_resource_tests(GeoEngineer::Resources::AwsVpcDhcpOption, 'aws_vpc_dhcp_option')
+  name_tag_geo_id_tests(GeoEngineer::Resources::AwsVpcDhcpOption)
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      ec2 = AwsClients.ec2
+      stub = ec2.stub_data(
+        :describe_dhcp_options,
+        {
+          vpc_dhcp_options: [
+            { dhcp_option_id: 'name1', tags: [{ key: 'Name', value: 'one' }] },
+            { dhcp_option_id: 'name2', tags: [{ key: 'Name', value: 'two' }] }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_vpc_dhcp_options, stub)
+      remote_resources = GeoEngineer::Resources::AwsVpcDhcpOption._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end

--- a/spec/utils/has_validations_spec.rb
+++ b/spec/utils/has_validations_spec.rb
@@ -32,4 +32,49 @@ describe("HasValidations") do
     expect(errs).to include('sub')
     expect(errs).to include('super')
   end
+
+  describe "#validate_at_least_one_present" do
+    it "checks that at least of the specified attributes is defined" do
+      class Subject < GeoEngineer::Resource
+        include HasValidations
+        validate -> {
+          validate_at_least_one_present([:foo, :bar, :baz])
+        }
+
+        def _terraform_id
+          'id'
+        end
+      end
+
+      valid = Subject.new('subject', 'id') { foo("quack") }
+      expect(valid.errors).to be_empty
+
+      invalid = Subject.new('subject', 'id') { qux("quack") }
+      expect(invalid.errors).to_not be_empty
+    end
+  end
+
+  describe "#validate_at_least_one_present" do
+    it "checks that at least of the specified attributes is defined" do
+      class Subject < GeoEngineer::Resource
+        include HasValidations
+        validate -> {
+          validate_only_one_present([:foo, :bar, :baz])
+        }
+
+        def _terraform_id
+          'id'
+        end
+      end
+
+      valid = Subject.new('subject', 'id') { foo("quack") }
+      expect(valid.errors).to be_empty
+
+      invalid = Subject.new('subject', 'id') {
+        foo("quack")
+        bar("meow")
+      }
+      expect(invalid.errors).to_not be_empty
+    end
+  end
 end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Added the ability to codify DHCP Options set.

By itself, a pretty standard resource.

Also added a couple additional validations:
- validate_at_least_one_present, which checks that at least on of the
specified attributes has been defined. This is useful when there are
number of attributes that could be defined, and we need at least one.
- validate_only_one_present, which is similar to at_least_one_present,
but checks that exactly one of the attributes is defined.

How has it been tested:
=======================
Added specs

@mentions:
==========
@grahamjenson