### PR TITLE
New: Add AWS Nat Gateway

### DIFF
--- a/lib/geoengineer/resources/aws_nat_gateway.rb
+++ b/lib/geoengineer/resources/aws_nat_gateway.rb
@@ -1,0 +1,25 @@
+########################################################################
+# AwsNatGateway is the +aws_nat_gateway+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/nat_gateway.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsNatGateway < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:subnet_id, :allocation_id]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{allocation_id}::#{subnet_id}" } }
+
+  def self._fetch_remote_resources
+    AwsClients.ec2.describe_nat_gateways['nat_gateways'].map(&:to_h).map do |gateway|
+      # AWS SDK has `nat_gateway_addresses` as an array, but you should only be able to
+      # have exactly 1 elastic IP association. This logic should cover the bases...
+      allocation = gateway[:nat_gateway_addresses].find { |addr| addr.key?(:allocation_id) }
+      gateway.merge(
+        {
+          _terraform_id: gateway[:nat_gateway_id],
+          _geo_id: "#{allocation[:allocation_id]}::#{gateway[:subnet_id]}"
+        }
+      )
+    end
+  end
+end

--- a/spec/resources/aws_nat_gateway_spec.rb
+++ b/spec/resources/aws_nat_gateway_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper'
+
+describe("GeoEngineer::Resources::AwsNatGateway") do
+  common_resource_tests(GeoEngineer::Resources::AwsNatGateway, 'aws_nat_gateway')
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      ec2 = AwsClients.ec2
+      stub = ec2.stub_data(
+        :describe_nat_gateways,
+        {
+          nat_gateways: [
+            {
+              nat_gateway_id: 'name1',
+              subnet_id: 's1',
+              nat_gateway_addresses: [{ allocation_id: 'a1' }]
+            },
+            {
+              nat_gateway_id: 'name2',
+              subnet_id: 's2',
+              nat_gateway_addresses: [{ allocation_id: 'a2' }]
+            }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_nat_gateways, stub)
+      remote_resources = GeoEngineer::Resources::AwsNatGateway._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Add the ability to codify AWS Nat Gateways.

The only weird thing with this resource is that AWS SDK has buried the
information about the IP allocation in a `nat_gateway_addresses` array,
even though a Gateway can have exactly 1 EIP allocation. ¯\_(ツ)_/¯

How has it been tested:
=======================
The usual specs.

@mentions:
==========
@grahamjenson
@lukedemi