### PR TITLE
New: Add aws_customer_gateway

### DIFF
--- a/lib/geoengineer/resources/aws_customer_gateway.rb
+++ b/lib/geoengineer/resources/aws_customer_gateway.rb
@@ -1,20 +1,20 @@
 ########################################################################
-# AwsInternetGateway is the +aws_internet_gateway+ terrform resource,
+# AwsCustomerGateway is the +aws_customer_gateway+ terrform resource,
 #
-# {https://www.terraform.io/docs/providers/aws/r/internet_gateway.html Terraform Docs}
+# {https://www.terraform.io/docs/providers/aws/r/customer_gateway.html Terraform Docs}
 ########################################################################
-class GeoEngineer::Resources::AwsInternetGateway < GeoEngineer::Resource
-  validate -> { validate_required_attributes([:vpc_id]) }
+class GeoEngineer::Resources::AwsCustomerGateway < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:bgp_asn, :ip_address, :type]) }
   validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
 
   def self._fetch_remote_resources
-    AwsClients.ec2.describe_internet_gateways['internet_gateways'].map(&:to_h).map do |gateway|
+    AwsClients.ec2.describe_customer_gateways['customer_gateways'].map(&:to_h).map do |gateway|
       gateway.merge(
         {
-          _terraform_id: gateway[:internet_gateway_id],
+          _terraform_id: gateway[:customer_gateway_id],
           _geo_id: gateway[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )

--- a/lib/geoengineer/resources/aws_instance.rb
+++ b/lib/geoengineer/resources/aws_instance.rb
@@ -15,10 +15,13 @@ class GeoEngineer::Resources::AwsInstance < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources
-    _all_remote_instances.map do |i|
-      i[:_terraform_id] = i[:instance_id]
-      i[:_geo_id] = i[:tags] ? i[:tags].select { |x| x[:key] == "Name" }.first[:value] : nil
-      i
+    _all_remote_instances.map do |instance|
+      instance.merge(
+        {
+          _terraform_id: instance[:instance_id],
+          _geo_id: instance[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+        }
+      )
     end
   end
 end

--- a/lib/geoengineer/resources/aws_route_table.rb
+++ b/lib/geoengineer/resources/aws_route_table.rb
@@ -18,7 +18,7 @@ class GeoEngineer::Resources::AwsRouteTable < GeoEngineer::Resource
       route_table.merge(
         {
           _terraform_id: route_table[:route_table_id],
-          _geo_id: route_table[:tags].find { |tag| tag[:key] == "Name" }[:value]
+          _geo_id: route_table[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_security_group.rb
+++ b/lib/geoengineer/resources/aws_security_group.rb
@@ -44,10 +44,13 @@ class GeoEngineer::Resources::AwsSecurityGroup < GeoEngineer::Resource
 
   def self._fetch_remote_resources
     AwsClients.ec2.describe_security_groups['security_groups'].map(&:to_h).map do |sg|
-      sg[:name] = sg[:group_name]
-      sg[:_terraform_id] = sg[:group_id]
-      sg[:_geo_id] = sg[:tags] ? sg[:tags].select { |x| x[:key] == "Name" }.first[:value] : nil
-      sg
+      sg.merge(
+        {
+          name: sg[:group_name],
+          _terraform_id: sg[:group_id],
+          _geo_id: sg[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+        }
+      )
     end
   end
 end

--- a/lib/geoengineer/resources/aws_subnet.rb
+++ b/lib/geoengineer/resources/aws_subnet.rb
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsSubnet < GeoEngineer::Resource
       subnet.merge(
         {
           _terraform_id: subnet[:subnet_id],
-          _geo_id: subnet[:tags].find { |tag| tag[:key] == "Name" }[:value]
+          _geo_id: subnet[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_vpc.rb
+++ b/lib/geoengineer/resources/aws_vpc.rb
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsVpc < GeoEngineer::Resource
       vpc.merge(
         {
           _terraform_id: vpc[:vpc_id],
-          _geo_id: vpc[:tags].find { |tag| tag[:key] == "Name" }[:value]
+          _geo_id: vpc[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_vpc_dhcp_options.rb
+++ b/lib/geoengineer/resources/aws_vpc_dhcp_options.rb
@@ -21,7 +21,7 @@ class GeoEngineer::Resources::AwsVpcDhcpOptions < GeoEngineer::Resource
       options.merge(
         {
           _terraform_id: options[:dhcp_options_id],
-          _geo_id: options[:tags].find { |tag| tag[:key] == "Name" }[:value]
+          _geo_id: options[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/spec/resources/aws_customer_gateway_spec.rb
+++ b/spec/resources/aws_customer_gateway_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../spec_helper'
+
+describe("GeoEngineer::Resources::AwsCustomerGateway") do
+  common_resource_tests(GeoEngineer::Resources::AwsCustomerGateway, 'aws_customer_gateway')
+  name_tag_geo_id_tests(GeoEngineer::Resources::AwsCustomerGateway)
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      ec2 = AwsClients.ec2
+      stub = ec2.stub_data(
+        :describe_customer_gateways,
+        {
+          customer_gateways: [
+            { customer_gateway_id: 'name1', tags: [{ key: 'Name', value: 'one' }] },
+            { customer_gateway_id: 'name2', tags: [{ key: 'Name', value: 'two' }] }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_customer_gateways, stub)
+      remote_resources = GeoEngineer::Resources::AwsCustomerGateway._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Add the ability to codify AWS Customer Gateways.

Also realized that in the case where the existing AWS resources don't
have a `Name` tag, the code I had been using would fail, due to:
```
irb(main):001:0> nil[:foo]
NoMethodError: undefined method `[]' for nil:NilClass
```
So I changed all instances where I could find of tag lookup to:
```
.merge(
  {
    _terraform_id: ...,
    _geo_id: resource[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
  }

)
```
Which will return a `nil` geo ID if the `Name` tag does not exist.
```
irb(main):001:0> nil&.dig(:foo)
=> nil
```

How has it been tested:
=======================
The usual tests

@mentions:
==========
@grahamjenson