### PR TITLE
New: Add AWS VPN (Private) Gateway

### DIFF
--- a/lib/geoengineer/resources/aws_vpn_gateway.rb
+++ b/lib/geoengineer/resources/aws_vpn_gateway.rb
@@ -1,0 +1,23 @@
+########################################################################
+# AwsVpnGateway is the +aws_vpn_gateway+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/vpn_gateway.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsVpnGateway < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:vpc_id]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
+
+  def self._fetch_remote_resources
+    AwsClients.ec2.describe_vpn_gateways['vpn_gateways'].map(&:to_h).map do |gateway|
+      gateway.merge(
+        {
+          _terraform_id: gateway[:vpn_gateway_id],
+          _geo_id: gateway[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws_vpn_gateway.rb
+++ b/lib/geoengineer/resources/aws_vpn_gateway.rb
@@ -4,7 +4,6 @@
 # {https://www.terraform.io/docs/providers/aws/r/vpn_gateway.html Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsVpnGateway < GeoEngineer::Resource
-  validate -> { validate_required_attributes([:vpc_id]) }
   validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }

--- a/spec/resources/aws_vpn_gateway_spec.rb
+++ b/spec/resources/aws_vpn_gateway_spec.rb
@@ -1,0 +1,24 @@
+require_relative '../spec_helper'
+
+describe("GeoEngineer::Resources::AwsVpnGateway") do
+  common_resource_tests(GeoEngineer::Resources::AwsVpnGateway, 'aws_vpn_gateway')
+  name_tag_geo_id_tests(GeoEngineer::Resources::AwsVpnGateway)
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      ec2 = AwsClients.ec2
+      stub = ec2.stub_data(
+        :describe_vpn_gateways,
+        {
+          vpn_gateways: [
+            { vpn_gateway_id: 'name1', tags: [{ key: 'Name', value: 'one' }] },
+            { vpn_gateway_id: 'name2', tags: [{ key: 'Name', value: 'two' }] }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_vpn_gateways, stub)
+      remote_resources = GeoEngineer::Resources::AwsVpnGateway._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Added the ability to codify AWS VPN Gateways, also known as Private
Gateways.

The only thing that really needs scrutiny here is whether or not to
require the `vpc_id`.

The Terraform docs have it as optional, but seems kinda silly to create
one without attaching to a VPC. I could be wrong though, and thus
unfairly limiting Geo.

How has it been tested:
=======================
The usual.