### PR TITLE
New: Add AWS VPN Gateway Attachment

### DIFF
--- a/lib/geoengineer/resources/aws_vpn_gateway_attachment.rb
+++ b/lib/geoengineer/resources/aws_vpn_gateway_attachment.rb
@@ -1,12 +1,14 @@
 ########################################################################
-# AwsRoute is the +aws_route+ terrform resource,
+# AwsVpnGatewayAttachment is the +aws_vpn_gateway_attachment+ terrform resource,
 #
-# {https://www.terraform.io/docs/providers/aws/r/route.html Terraform Docs}
+# {https://www.terraform.io/docs/providers/aws/r/vpn_gateway_attachment.html Terraform Docs}
 ########################################################################
-class GeoEngineer::Resources::AwsRoute < GeoEngineer::Resource
+class GeoEngineer::Resources::AwsVpnGatewayAttachment < GeoEngineer::Resource
   validate -> { validate_required_attributes([:vpc_id, :vpn_gateway_id]) }
 
-  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> {
+    _terraform_id -> { "vpn-attachment-#{Crc32.hashcode(vpc_id + '-' + vpn_gateway_id)}" }
+  }
   after :initialize, -> { _geo_id -> { "#{vpc_id}::#{vpn_gateway_id}" } }
 
   def self._fetch_remote_resources
@@ -15,7 +17,7 @@ class GeoEngineer::Resources::AwsRoute < GeoEngineer::Resource
       .describe_vpn_gateways['vpn_gateways']
       .map(&:to_h)
       .select { |gateway| !gateway[:vpc_attachments].empty? }
-      .map { |attachment| _generate_attachment(gateway) }
+      .map { |gateway| _generate_attachment(gateway) }
   end
 
   def self._generate_attachment(gateway)

--- a/lib/geoengineer/resources/aws_vpn_gateway_attachment.rb
+++ b/lib/geoengineer/resources/aws_vpn_gateway_attachment.rb
@@ -1,0 +1,35 @@
+########################################################################
+# AwsRoute is the +aws_route+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/route.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsRoute < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:vpc_id, :vpn_gateway_id]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{vpc_id}::#{vpn_gateway_id}" } }
+
+  def self._fetch_remote_resources
+    AwsClients
+      .ec2
+      .describe_vpn_gateways['vpn_gateways']
+      .map(&:to_h)
+      .select { |gateway| !gateway[:vpc_attachments].empty? }
+      .map { |attachment| _generate_attachment(gateway) }
+  end
+
+  def self._generate_attachment(gateway)
+    # Terraform ID generation via:
+    # https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_vpn_gateway_attachment.go#L209
+    vpc_id = gateway[:vpc_attachments].first[:vpc_id]
+    id_string = "#{vpc_id}-#{gateway[:vpn_gateway_id]}"
+    terraform_id = "vpn-attachment-#{Crc32.hashcode(id_string)}"
+
+    {
+      _terraform_id: terraform_id,
+      _geo_id: "#{vpc_id}::#{gateway[:vpn_gateway_id]}",
+      vpn_gateway_id: gateway[:vpn_gateway_id],
+      vpc_id: vpc_id
+    }
+  end
+end

--- a/spec/resources/aws_vpn_gateway_attachment_spec.rb
+++ b/spec/resources/aws_vpn_gateway_attachment_spec.rb
@@ -1,8 +1,10 @@
 require_relative '../spec_helper'
 
-describe("GeoEngineer::Resources::AwsVpnGateway") do
-  common_resource_tests(GeoEngineer::Resources::AwsVpnGateway, 'aws_vpn_gateway')
-  name_tag_geo_id_tests(GeoEngineer::Resources::AwsVpnGateway)
+describe("GeoEngineer::Resources::AwsVpnGatewayAttachment") do
+  common_resource_tests(
+    GeoEngineer::Resources::AwsVpnGatewayAttachment,
+    'aws_vpn_gateway_attachment'
+  )
 
   describe "#_fetch_remote_resources" do
     let(:ec2) { AwsClients.ec2 }
@@ -32,7 +34,7 @@ describe("GeoEngineer::Resources::AwsVpnGateway") do
     end
 
     it 'should create list of hashes from returned AWS SDK' do
-      remote_resources = GeoEngineer::Resources::AwsVpnGateway._fetch_remote_resources
+      remote_resources = GeoEngineer::Resources::AwsVpnGatewayAttachment._fetch_remote_resources
       expect(remote_resources.length).to eq(2)
     end
   end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Add the ability to codify AWS VPN Gateway Attachments, which in my view,
are an inferior resource. Seems like you should almost always define the
VPC association in the VPN Gateway declaration. But hey, that's just me.

This one also uses the Crc32 Hashcode, which I realized means that I can
actually derive the terraform ID without fetching remote resources.
Cool.

How has it been tested:
=======================
The usual.