### PR TITLE
Fixes resource validation on naming for use with aws_iam_policy_attachment

### DIFF
--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -139,7 +139,6 @@ class GeoCLI
       throw "Environment not set" unless @environment
 
       @environment.execute_lifecycle(:before, action_name.to_sym)
-
       errs = @environment.errors.flatten.sort
       return print_validation_errors(errs) unless errs.empty?
 

--- a/lib/geoengineer/environment.rb
+++ b/lib/geoengineer/environment.rb
@@ -17,21 +17,33 @@ class GeoEngineer::Environment
 
   # Validate resources have unique attributes
   validate -> {
-    resources_grouped_by(&:terraform_name)
-      .select { |k, v| v.length > 1 }
-      .map { |k, v| "Non-unique type.id #{v.first.for_resource}" }
+    resources = resources_of_class_grouped_by(&:terraform_name)
+
+    resources.map do |klass, grouped_resources|
+      grouped_resources
+        .select { |k, v| v.length > 1 }
+        .map { |k, v| "Non-unique type.id #{v.first.for_resource}" }
+    end.flatten
   }
 
   validate -> {
-    resources_grouped_by(&:_terraform_id)
-      .select { |k, v| v.length > 1 && !v.first._terraform_id.nil? }
-      .map { |k, v| "Non-unique _terraform_id #{v.first._terraform_id} #{v.first.for_resource}" }
+    resources = resources_of_class_grouped_by(&:_terraform_id)
+
+    resources.map do |klass, grouped_resources|
+      grouped_resources
+        .select { |k, v| v.length > 1 && !v.first._terraform_id.nil? }
+        .map { |k, v| "Non-unique _terraform_id #{v.first._terraform_id} #{v.first.for_resource}" }
+    end.flatten
   }
 
   validate -> {
-    resources_grouped_by(&:_geo_id)
-      .select { |k, v| v.length > 1 }
-      .map { |k, v| "Non-unique _geo_id #{v.first._geo_id} #{v.first.for_resource}" }
+    resources = resources_of_class_grouped_by(&:_geo_id)
+
+    resources.map do |klass, grouped_resources|
+      grouped_resources
+        .select { |k, v| v.length > 1 }
+        .map { |k, v| "Non-unique _geo_id #{v.first._geo_id} #{v.first.for_resource}" }
+    end.flatten
   }
 
   # Validate all resources

--- a/lib/geoengineer/environment.rb
+++ b/lib/geoengineer/environment.rb
@@ -1,3 +1,4 @@
+
 ########################################################################
 # An Environment is a group of projects, resources and attributes,
 # build to create a terraform file.
@@ -17,7 +18,7 @@ class GeoEngineer::Environment
 
   # Validate resources have unique attributes
   validate -> {
-    resources = resources_of_class_grouped_by(&:terraform_name)
+    resources = resources_of_type_grouped_by(&:terraform_name)
 
     resources.map do |klass, grouped_resources|
       grouped_resources
@@ -27,7 +28,7 @@ class GeoEngineer::Environment
   }
 
   validate -> {
-    resources = resources_of_class_grouped_by(&:_terraform_id)
+    resources = resources_of_type_grouped_by(&:_terraform_id)
 
     resources.map do |klass, grouped_resources|
       grouped_resources
@@ -37,7 +38,7 @@ class GeoEngineer::Environment
   }
 
   validate -> {
-    resources = resources_of_class_grouped_by(&:_geo_id)
+    resources = resources_of_type_grouped_by(&:_geo_id)
 
     resources.map do |klass, grouped_resources|
       grouped_resources
@@ -167,6 +168,7 @@ class GeoEngineer::Environment
 
   def to_terraform_state
     reses = all_resources.select(&:_terraform_id) # _terraform_id must not be nil
+
     reses = reses.map { |r| { "#{r.type}.#{r.id}" => r.to_terraform_state() } }.reduce({}, :merge)
 
     {

--- a/lib/geoengineer/resources/aws_iam_policy.rb
+++ b/lib/geoengineer/resources/aws_iam_policy.rb
@@ -19,9 +19,12 @@ class GeoEngineer::Resources::AwsIamPolicy < GeoEngineer::Resource
     policy = _get_policy_document(arn, default_version_id)
 
     tfstate = super
-    tfstate[:primary][:attributes] = {
-      'policy' => policy
-    }
+
+    attributes = { 'policy' => policy }
+    attributes['arn'] = arn if arn
+
+    tfstate[:primary][:attributes] = attributes
+
     tfstate
   end
 

--- a/lib/geoengineer/resources/aws_iam_policy_attachment.rb
+++ b/lib/geoengineer/resources/aws_iam_policy_attachment.rb
@@ -6,7 +6,8 @@
 class GeoEngineer::Resources::AwsIamPolicyAttachment < GeoEngineer::Resource
   validate -> { validate_required_attributes([:name, :policy_arn]) }
 
-  after :initialize, -> { _terraform_id -> { name.to_s } }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_reource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name.to_s } }
 
   def to_terraform_state
     tfstate = super
@@ -59,7 +60,7 @@ class GeoEngineer::Resources::AwsIamPolicyAttachment < GeoEngineer::Resource
     policies.map do |policy|
       entities = _fetch_entities_for_policy(policy)
       attrs = collected_policy_attributes(policy, entities)
-      attrs[:_terraform_id] = policy[:policy_name]
+      attrs[:_terraform_id] = policy[:arn]
       attrs[:_geo_id] = policy[:policy_name]
       attrs
     end

--- a/lib/geoengineer/utils/has_resources.rb
+++ b/lib/geoengineer/utils/has_resources.rb
@@ -37,13 +37,25 @@ module HasResources
     find_resource(type, name)
   end
 
-  def resources_grouped_by
-    all_resources.each_with_object({}) do |r, c|
+  # Returns: { value1: [ ], value2: [ ] }
+  def resources_grouped_by(resources = all_resources)
+    resources.each_with_object({}) do |r, c|
       value = yield r
       c[value] ||= []
       c[value] << r
       c
     end
+  end
+
+  # Returns: { class1: { value1: [ ] }, class2: { value2: [ ] } }
+  def resources_of_class_grouped_by(&block)
+    grouped = resources_grouped_by(all_resources, &:class)
+
+    grouped_arr = grouped.map do |klass, resources|
+      [klass, resources_grouped_by(resources, &block)]
+    end
+
+    grouped_arr.to_h
   end
 
   def resources_of_type(type)

--- a/lib/geoengineer/utils/has_resources.rb
+++ b/lib/geoengineer/utils/has_resources.rb
@@ -38,8 +38,8 @@ module HasResources
   end
 
   # Returns: { value1: [ ], value2: [ ] }
-  def resources_grouped_by(resources = all_resources)
-    resources.each_with_object({}) do |r, c|
+  def resources_grouped_by(resources_to_group = all_resources)
+    resources_to_group.each_with_object({}) do |r, c|
       value = yield r
       c[value] ||= []
       c[value] << r
@@ -47,12 +47,12 @@ module HasResources
     end
   end
 
-  # Returns: { class1: { value1: [ ] }, class2: { value2: [ ] } }
-  def resources_of_class_grouped_by(&block)
-    grouped = resources_grouped_by(all_resources, &:class)
+  # Returns: { type1: { value1: [ ] }, type2: { value2: [ ] } }
+  def resources_of_type_grouped_by(&block)
+    grouped = resources_grouped_by(all_resources, &:type)
 
-    grouped_arr = grouped.map do |klass, resources|
-      [klass, resources_grouped_by(resources, &block)]
+    grouped_arr = grouped.map do |type, grouped_resources|
+      [type, resources_grouped_by(grouped_resources, &block)]
     end
 
     grouped_arr.to_h

--- a/spec/resources/aws_iam_policy_attachment_spec.rb
+++ b/spec/resources/aws_iam_policy_attachment_spec.rb
@@ -40,7 +40,7 @@ describe "GeoEngineer::Resources::AwsIamPolicy" do
       expect(resources.count).to eql 1
 
       test_attachment = resources.first
-      expect(test_attachment[:_terraform_id]).to eql('Fake-Aws-ARN')
+      expect(test_attachment[:_terraform_id]).to eql('arn:aws:iam::aws:policy/xyv/FakeAwsARN')
       expect(test_attachment[:_geo_id]).to eql('Fake-Aws-ARN')
       expect(test_attachment[:users].count).to eql 2
       expect(test_attachment[:groups].count).to eql 1


### PR DESCRIPTION
Previously geo would validate the names of all resources to avoid collisions. Here, the validation changes so that geo only validates the singularity of names across one resource type