### PR TITLE
Fix: Account for resources with no tags

### DIFF
--- a/lib/geoengineer/resources/aws_customer_gateway.rb
+++ b/lib/geoengineer/resources/aws_customer_gateway.rb
@@ -15,7 +15,7 @@ class GeoEngineer::Resources::AwsCustomerGateway < GeoEngineer::Resource
       gateway.merge(
         {
           _terraform_id: gateway[:customer_gateway_id],
-          _geo_id: gateway[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: gateway[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_instance.rb
+++ b/lib/geoengineer/resources/aws_instance.rb
@@ -19,7 +19,7 @@ class GeoEngineer::Resources::AwsInstance < GeoEngineer::Resource
       instance.merge(
         {
           _terraform_id: instance[:instance_id],
-          _geo_id: instance[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: instance[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_internet_gateway.rb
+++ b/lib/geoengineer/resources/aws_internet_gateway.rb
@@ -15,7 +15,7 @@ class GeoEngineer::Resources::AwsInternetGateway < GeoEngineer::Resource
       gateway.merge(
         {
           _terraform_id: gateway[:internet_gateway_id],
-          _geo_id: gateway[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: gateway[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_network_acl.rb
+++ b/lib/geoengineer/resources/aws_network_acl.rb
@@ -30,7 +30,7 @@ class GeoEngineer::Resources::AwsNetworkAcl < GeoEngineer::Resource
       network_acl.merge(
         {
           _terraform_id: network_acl[:network_acl_id],
-          _geo_id: network_acl[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: network_acl[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_route_table.rb
+++ b/lib/geoengineer/resources/aws_route_table.rb
@@ -18,7 +18,7 @@ class GeoEngineer::Resources::AwsRouteTable < GeoEngineer::Resource
       route_table.merge(
         {
           _terraform_id: route_table[:route_table_id],
-          _geo_id: route_table[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: route_table[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_security_group.rb
+++ b/lib/geoengineer/resources/aws_security_group.rb
@@ -48,7 +48,7 @@ class GeoEngineer::Resources::AwsSecurityGroup < GeoEngineer::Resource
         {
           name: sg[:group_name],
           _terraform_id: sg[:group_id],
-          _geo_id: sg[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: sg[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_subnet.rb
+++ b/lib/geoengineer/resources/aws_subnet.rb
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsSubnet < GeoEngineer::Resource
       subnet.merge(
         {
           _terraform_id: subnet[:subnet_id],
-          _geo_id: subnet[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: subnet[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_vpc.rb
+++ b/lib/geoengineer/resources/aws_vpc.rb
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsVpc < GeoEngineer::Resource
       vpc.merge(
         {
           _terraform_id: vpc[:vpc_id],
-          _geo_id: vpc[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: vpc[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_vpc_dhcp_options.rb
+++ b/lib/geoengineer/resources/aws_vpc_dhcp_options.rb
@@ -21,7 +21,7 @@ class GeoEngineer::Resources::AwsVpcDhcpOptions < GeoEngineer::Resource
       options.merge(
         {
           _terraform_id: options[:dhcp_options_id],
-          _geo_id: options[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: options[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/lib/geoengineer/resources/aws_vpn_gateway.rb
+++ b/lib/geoengineer/resources/aws_vpn_gateway.rb
@@ -14,7 +14,7 @@ class GeoEngineer::Resources::AwsVpnGateway < GeoEngineer::Resource
       gateway.merge(
         {
           _terraform_id: gateway[:vpn_gateway_id],
-          _geo_id: gateway[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: gateway[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
         }
       )
     end

--- a/spec/resources/aws_network_acl_rule_spec.rb
+++ b/spec/resources/aws_network_acl_rule_spec.rb
@@ -4,8 +4,8 @@ describe("GeoEngineer::Resources::AwsNetworkAclRule") do
   common_resource_tests(GeoEngineer::Resources::AwsNetworkAclRule, 'aws_network_acl_rule')
 
   describe "#_fetch_remote_resources" do
-    it 'should create list of hashes from returned AWS SDK' do
-      ec2 = AwsClients.ec2
+    let(:ec2) { AwsClients.ec2 }
+    before do
       stub = ec2.stub_data(
         :describe_network_acls,
         {
@@ -42,6 +42,13 @@ describe("GeoEngineer::Resources::AwsNetworkAclRule") do
         }
       )
       ec2.stub_responses(:describe_network_acls, stub)
+    end
+
+    after do
+      ec2.stub_responses(:describe_network_acls, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
       remote_resources = GeoEngineer::Resources::AwsNetworkAclRule._fetch_remote_resources
       expect(remote_resources.length).to eq(2)
     end

--- a/spec/resources/aws_network_acl_spec.rb
+++ b/spec/resources/aws_network_acl_spec.rb
@@ -5,8 +5,8 @@ describe("GeoEngineer::Resources::AwsNetworkAcl") do
   name_tag_geo_id_tests(GeoEngineer::Resources::AwsNetworkAcl)
 
   describe "#_fetch_remote_resources" do
-    it 'should create list of hashes from returned AWS SDK' do
-      ec2 = AwsClients.ec2
+    let(:ec2) { AwsClients.ec2 }
+    before do
       stub = ec2.stub_data(
         :describe_network_acls,
         {
@@ -17,6 +17,13 @@ describe("GeoEngineer::Resources::AwsNetworkAcl") do
         }
       )
       ec2.stub_responses(:describe_network_acls, stub)
+    end
+
+    after do
+      ec2.stub_responses(:describe_network_acls, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
       remote_resources = GeoEngineer::Resources::AwsNetworkAcl._fetch_remote_resources
       expect(remote_resources.length).to eq(2)
     end


### PR DESCRIPTION
Type of change:
===============
- Bug fix

What changed? ... and Why:
==========================
Original syntax:
```
_geo_id: resource[:tags] ? resource[:tags].select { |x| x[:key] == "Name" }.first[:value] : nil
```
While this would work for cases where resource had or did not have tags,
it would fail for the case where it had tags, but not a "Name" tag.

I modified it to this:
```
_geo_id: resource[:tags].find { |tag| tag[:key] == "Name" }&.dig(:value)
```
Which traded one problem for another - if the resource didn't have ANY
tags defined, it would error.

So I solved with this:
```
_geo_id: resource[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
```
Which now covers all the bases.

How has it been tested:
=======================
Added an additional spec.

@mentions:
==========
@lukedemi