### PR TITLE
Explicitly mark those resources that don't support tagging

### DIFF
--- a/lib/geoengineer/resources/aws_nat_gateway.rb
+++ b/lib/geoengineer/resources/aws_nat_gateway.rb
@@ -9,6 +9,10 @@ class GeoEngineer::Resources::AwsNatGateway < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{allocation_id}::#{subnet_id}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients.ec2.describe_nat_gateways['nat_gateways'].map(&:to_h).map do |gateway|
       # AWS SDK has `nat_gateway_addresses` as an array, but you should only be able to

--- a/lib/geoengineer/resources/aws_network_acl_rule.rb
+++ b/lib/geoengineer/resources/aws_network_acl_rule.rb
@@ -22,6 +22,10 @@ class GeoEngineer::Resources::AwsNetworkAclRule < GeoEngineer::Resource
     }
   }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients
       .ec2

--- a/lib/geoengineer/resources/aws_route.rb
+++ b/lib/geoengineer/resources/aws_route.rb
@@ -9,6 +9,10 @@ class GeoEngineer::Resources::AwsRoute < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{route_table_id}|#{destination_cidr_block}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients
       .ec2

--- a/lib/geoengineer/resources/aws_route53_record.rb
+++ b/lib/geoengineer/resources/aws_route53_record.rb
@@ -15,6 +15,10 @@ class GeoEngineer::Resources::AwsRoute53Record < GeoEngineer::Resource
 
   after :initialize, -> { _terraform_id -> { "#{zone_id}_#{name}_#{type}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     _fetch_zones.map { |zone| _fetch_records_for_zone(zone) }.flatten.compact
   end

--- a/lib/geoengineer/resources/aws_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_route_table_association.rb
@@ -9,6 +9,10 @@ class GeoEngineer::Resources::AwsRouteTableAssociation < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{subnet_id}::#{route_table_id}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients
       .ec2

--- a/lib/geoengineer/resources/aws_vpc_dhcp_options_association.rb
+++ b/lib/geoengineer/resources/aws_vpc_dhcp_options_association.rb
@@ -10,6 +10,10 @@ class GeoEngineer::Resources::AwsVpcDhcpOptionsAssociation < GeoEngineer::Resour
     _terraform_id -> { "#{dhcp_options_id}-#{vpc_id}" }
   }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients
       .ec2

--- a/lib/geoengineer/resources/aws_vpc_endpoint.rb
+++ b/lib/geoengineer/resources/aws_vpc_endpoint.rb
@@ -9,6 +9,10 @@ class GeoEngineer::Resources::AwsVpcEndpoint < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{vpc_id}::#{service_name}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients.ec2.describe_vpc_endpoints['vpc_endpoints'].map(&:to_h).map do |endpoint|
       endpoint.merge(

--- a/lib/geoengineer/resources/aws_vpn_connection_route.rb
+++ b/lib/geoengineer/resources/aws_vpn_connection_route.rb
@@ -8,6 +8,10 @@ class GeoEngineer::Resources::AwsVpnConnectionRoute < GeoEngineer::Resource
 
   after :initialize, -> { _terraform_id -> { "#{destination_cidr_block}:#{vpn_connection_id}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients
       .ec2

--- a/lib/geoengineer/resources/aws_vpn_gateway_attachment.rb
+++ b/lib/geoengineer/resources/aws_vpn_gateway_attachment.rb
@@ -11,6 +11,10 @@ class GeoEngineer::Resources::AwsVpnGatewayAttachment < GeoEngineer::Resource
   }
   after :initialize, -> { _geo_id -> { "#{vpc_id}::#{vpn_gateway_id}" } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources
     AwsClients
       .ec2


### PR DESCRIPTION
If resource doesn't support flags, set `support_flags?` to `false`