### PR TITLE
New: Add Lambda Permission to Geo

### DIFF
--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -164,24 +164,28 @@ class GeoEngineer::Resource
     "for resource \"#{type}.#{id}\" #{in_project}"
   end
 
-  # VALIDATION METHODS
-  def support_tags?
-    true
+  def setup_tags_if_needed
+    tags {} unless tags
   end
 
   def merge_project_tags
-    return unless self.project
-    return unless self.project.tags
-    return unless self.support_tags?
+    return unless self.project && self.project.tags && self.support_tags?
 
-    tags {} unless tags # define tag subresource if nonexistent
+    setup_tags_if_needed
 
-    project_tags_hash = self.project.all_tags.map(&:attributes).reduce({}, :merge)
-    project_tags_hash.each do |key, value|
-      next if tags.attributes[key]
-      tags.attributes[key] = value
-    end
+    self
+      .project
+      .all_tags
+      .map(&:attributes)
+      .reduce({}, :merge)
+      .each { |key, value| tags.attributes[key] ||= value }
+
     tags
+  end
+
+  # VALIDATION METHODS
+  def support_tags?
+    true
   end
 
   def validate_required_subresource(subresource)

--- a/lib/geoengineer/resources/aws_lambda_permission.rb
+++ b/lib/geoengineer/resources/aws_lambda_permission.rb
@@ -1,0 +1,74 @@
+########################################################################
+# AwsLambdaPermission is the +aws_lambda_function+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/lambda_permission.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsLambdaPermission < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:action, :function_name, :principal, :statement_id]) }
+
+  after :initialize, -> { _terraform_id -> { statement_id } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_functions
+    AwsClients
+      .lambda
+      .list_functions['functions']
+      .map(&:to_h)
+  end
+
+  def self._fetch_policy(function)
+    policy = AwsClients.lambda.get_policy({ function_name: function[:function_name] })&.policy
+    parsed = _parse_policy(policy) if policy
+    function.merge({ policy: parsed }) if parsed
+  end
+
+  def self._parse_policy(policy)
+    _deep_symbolize_keys(JSON.parse(policy))
+  rescue JSON::ParserError
+    nil
+  end
+
+  def self._deep_symbolize_keys(obj)
+    if obj.is_a?(Hash)
+      obj.each_with_object({}) do |(key, value), hash|
+        hash[key.to_sym] = _deep_symbolize_keys(value)
+      end
+    elsif obj.is_a?(Array)
+      obj.map { |value| _deep_symbolize_keys(value) }
+    else
+      obj
+    end
+  end
+
+  def self._create_permission(function)
+    policy = function[:policy]
+    policy[:Statement].map do |statement|
+      # Note that the keys for a statement objection are all CamelCased
+      # Whereas most other keys in this repo are snake_cased
+      statement.merge(
+        {
+          _terraform_id: statement[:Sid],
+          function_name: function[:function_name],
+          function_version: function[:version]
+        }
+      )
+    end
+  end
+
+  # Right now, this only fetches policies for the $LATEST version
+  # If we want to support fetching the permissions for all of the aliases as well,
+  # We'll need to add another call per function, bring total calls to 2N+1...
+  # Same deal if we need to support older versions...
+  # (excluding any extra calls for pagination). Less than ideal...
+  def self._fetch_remote_resources
+    _fetch_functions
+      .map { |function| _fetch_policy(function) }
+      .compact
+      .map { |function| _create_permission(function) }
+      .flatten
+      .compact
+  end
+end

--- a/spec/resources/aws_lambda_alias_spec.rb
+++ b/spec/resources/aws_lambda_alias_spec.rb
@@ -20,8 +20,7 @@ describe("GeoEngineer::Resources::AwsLambdaAlias") do
       aws_client.stub_responses(
         :list_aliases, {
           aliases: [
-            { name: "foonew", alias_arn: "arn:aws:lambda:fooalias", function_version: "1" },
-            { name: "barnew", alias_arn: "arn:aws:lambda:baralias", function_version: "2" }
+            { name: "foonew", alias_arn: "arn:aws:lambda:alias", function_version: "1" }
           ]
         }
       )

--- a/spec/resources/aws_lambda_permission_spec.rb
+++ b/spec/resources/aws_lambda_permission_spec.rb
@@ -1,0 +1,90 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsLambdaPermission do
+  let(:aws_client) { AwsClients.lambda }
+
+  before { aws_client.setup_stubbing }
+
+  common_resource_tests(GeoEngineer::Resources::AwsLambdaPermission, 'aws_lambda_permission')
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :list_functions, {
+          functions: [
+            { function_name: "foo", role: "arn:aws:iam:one", handler: "export.foo", version: "1" },
+            { function_name: "bar", role: "arn:aws:iam:two", handler: "export.bar", version: "1" }
+          ]
+        }
+      )
+      aws_client.stub_responses(
+        :get_policy, {
+          policy: { Statement: [{ Sid: Random.rand(1000).to_s }] }.to_json
+        }
+      )
+    end
+
+    after do
+      aws_client.stub_responses(:list_functions, {})
+      aws_client.stub_responses(:get_policy, {})
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsLambdaPermission._fetch_remote_resources
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+
+  describe '#_parse_policy' do
+    it "returns nil is there is a JSON Parse error" do
+      expect(described_class._parse_policy("{ foo:  }")).to eq(nil)
+    end
+
+    context "with valid JSON" do
+      it "returns a hash with symbols for keys" do
+        policy = { foo: "bar", baz: ["qux"] }
+
+        expect(described_class._parse_policy(policy.to_json)).to eq(policy)
+        expect(described_class._parse_policy(policy.to_json).include?(:foo)).to eq(true)
+      end
+    end
+  end
+
+  describe '#_deep_symbolize_keys' do
+    let(:simple_obj) { JSON.parse({ foo: "bar", baz: "qux" }.to_json) }
+    let(:complex_obj) do
+      JSON.parse(
+        {
+          foo: {
+            bar: {
+              baz: [
+                { qux: "quack" }
+              ]
+            }
+          },
+          bar: [
+            { foo: "bar" },
+            nil,
+            [{ baz: "qux" }],
+            1,
+            "baz"
+          ]
+        }.to_json
+      )
+    end
+
+    it "converts top level keys to symbols" do
+      expect(simple_obj.keys.include?(:foo)).to eq(false)
+      expect(simple_obj.keys.include?("foo")).to eq(true)
+      converted = described_class._deep_symbolize_keys(simple_obj)
+      expect(converted.keys.include?(:foo)).to eq(true)
+      expect(converted.keys.include?("foo")).to eq(false)
+    end
+
+    it "converts deeply nested keys to symbols" do
+      converted = described_class._deep_symbolize_keys(complex_obj)
+      expect(converted[:foo][:bar][:baz].first[:qux]).to eq("quack")
+      expect(converted[:bar].first[:foo]).to eq("bar")
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
This introduces the concept of a Permission for AWS Lambda's.

My guess is that this resource will require a refactor soonish, due to:
- It being a relatively nascent AWS product
- Becuase of this ^, updates to AWS SDK are quite possible
- Listing remote policies is currently only configured for the lastest
version of a function
- Terraform arguments/state do not map nicely to data returned from the
AWS SDK
- No support for pagination yet, and unlike other resources, there is
high potential for a large number of lambda functions

I also fix a rubocop error in `lib/geoengineer/resource.rb`, and a
couple bugs with the AWS Lambda Alias resource and associated specs.

How has it been tested:
=======================
Added a number of tests, fixed another one