### PR TITLE
New: Add AWS Lambda Event Source Mapping to Geo

### DIFF
--- a/lib/geoengineer/resources/aws_lambda_event_source_mapping.rb
+++ b/lib/geoengineer/resources/aws_lambda_event_source_mapping.rb
@@ -1,0 +1,47 @@
+########################################################################
+# AwsLambdaEventSourceMappings is the +aws_lambda_event_source_mappings+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/lambda_event_source_mapping.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsLambdaEventSourceMapping < GeoEngineer::Resource
+  validate -> {
+    validate_required_attributes([:event_source_arn, :function_name, :starting_position])
+  }
+  validate -> {
+    if self.starting_position && !%w(TRIM_HORIZON LATEST).include?(self.starting_position)
+      ["starting_position must be either TRIM_HORIZON OR LATEST"]
+    end
+  }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { [event_source_arn, function_name].join("::") } }
+
+  def support_tags?
+    false
+  end
+
+  def short_type
+    "event_mapping"
+  end
+
+  def self._extract_name_from_arn(arn)
+    arn_components = arn.split(":")
+    arn_components[arn_components.index("function") + 1] if arn_components.index("function")
+  end
+
+  def self._fetch_remote_resources
+    AwsClients
+      .lambda
+      .list_event_source_mappings['event_source_mappings']
+      .map(&:to_h)
+      .map do |event|
+        geo_id = [event[:event_source_arn], self._extract_name_from_arn(event[:function_arn])]
+        event.merge(
+          {
+            _terraform_id: event[:uuid],
+            _geo_id: geo_id.join("::")
+          }
+        )
+      end
+  end
+end

--- a/lib/geoengineer/resources/aws_lambda_event_source_mapping.rb
+++ b/lib/geoengineer/resources/aws_lambda_event_source_mapping.rb
@@ -1,5 +1,5 @@
 ########################################################################
-# AwsLambdaEventSourceMappings is the +aws_lambda_event_source_mappings+ terrform resource,
+# AwsLambdaEventSourceMapping is the +aws_lambda_event_source_mapping+ terrform resource,
 #
 # {https://www.terraform.io/docs/providers/aws/r/lambda_event_source_mapping.html Terraform Docs}
 ########################################################################

--- a/spec/resources/aws_lambda_event_source_mapping_spec.rb
+++ b/spec/resources/aws_lambda_event_source_mapping_spec.rb
@@ -1,0 +1,53 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsLambdaEventSourceMapping do
+  let(:aws_client) { AwsClients.lambda }
+
+  before { aws_client.setup_stubbing }
+
+  common_resource_tests(
+    GeoEngineer::Resources::AwsLambdaEventSourceMapping,
+    'aws_lambda_event_source_mapping'
+  )
+
+  describe '#_fetch_remote_resources' do
+    before do
+      aws_client.stub_responses(
+        :list_event_source_mappings, {
+          event_source_mappings: [
+            {
+              uuid: "1",
+              event_source_arn: "arn:aws:kinesis:one",
+              function_arn: "arn:aws:lambda:function:foo"
+            },
+            {
+              uuid: "2",
+              event_source_arn: "arn:aws:kinesis:two",
+              function_arn: "arn:aws:lambda:function:bar:beta"
+            }
+          ]
+        }
+      )
+    end
+
+    after { aws_client.stub_responses(:list_event_source_mappings, {}) }
+
+    it 'should create an array of hashes from the AWS response' do
+      resources = GeoEngineer::Resources::AwsLambdaEventSourceMapping._fetch_remote_resources
+      expect(resources.count).to eql(2)
+    end
+  end
+
+  describe "#_extract_name_from_arn" do
+    it "returns nil if ARN does not contain function" do
+      expect(described_class._extract_name_from_arn("foo_bar")).to be_nil
+    end
+
+    it "returns item directly after function in ARN" do
+      expect(described_class._extract_name_from_arn("function:bar")).to eq('bar')
+      expect(described_class._extract_name_from_arn("aws:function:baz")).to eq('baz')
+      expect(described_class._extract_name_from_arn("aws:function:foo:qux")).to eq('foo')
+      expect(described_class._extract_name_from_arn("aws:function")).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Add the ability to codify AWS Lambda Event Source Mappings to
GeoEngineer. This resource was a bit tricky, as AWS doesn't return many
of the attributes required to create a mapping. The main problem being
that a `function_name` is required, but a `function_arn` is returned.

I'm assuming that all ARN's follow the convention I've noticed so far
of:
```
arn:aws:lambda:<region>:<account_id>:function:<function_name>:alias|version
```

To allow Geo to match remote with local resources, I built a helper method to
extract the function_name from the function_arn.

How has it been tested:
=======================
The usual specs, plus one for `#_extract_name_from_arn`.