### PR TITLE
Account for nil string values being passed to hashcode

### DIFF
--- a/lib/geoengineer/utils/crc32.rb
+++ b/lib/geoengineer/utils/crc32.rb
@@ -51,6 +51,8 @@ class Crc32
   end
 
   def self.hashcode(string)
+    return 0 unless string
+
     value = checksum(string).to_i
     return value if value >= 0
     return -value if value <= 0

--- a/spec/utils/crc32_spec.rb
+++ b/spec/utils/crc32_spec.rb
@@ -1,10 +1,14 @@
 require_relative '../spec_helper'
 
-describe 'Crc32' do
-  describe "hashcode" do
-    it "should match the output from Terraform's Go Implementation" do
+describe Crc32 do
+  describe "::hashcode" do
+    it "matches the output from Terraform's Go Implementation" do
       expect(Crc32.hashcode("0.0.0.0/0")).to eq(1_080_289_494)
       expect(Crc32.hashcode("10.60.0.0/16")).to eq(2_056_622_336)
+    end
+
+    it "returns 0 for nil strings" do
+      expect(Crc32.hashcode(nil)).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Ran into a case where a remote route didn't have a destination cidr block I think, so the hashcode failed. 