### PR TITLE
Refactor: validate_cidr_block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.gem
 .yardoc
 tmp
+.*.sw*

--- a/lib/geoengineer/resources/aws_security_group.rb
+++ b/lib/geoengineer/resources/aws_security_group.rb
@@ -31,7 +31,7 @@ class GeoEngineer::Resources::AwsSecurityGroup < GeoEngineer::Resource
     (self.all_ingress + self.all_egress).each do |in_eg|
       next unless in_eg.cidr_blocks
       in_eg.cidr_blocks.each do |cidr|
-        _, error = validate_cidr_block(cidr)
+        error = validate_cidr_block(cidr)
         errors << error unless error.nil?
       end
     end

--- a/lib/geoengineer/utils/has_validations.rb
+++ b/lib/geoengineer/utils/has_validations.rb
@@ -49,10 +49,9 @@ module HasValidations
   # Validates CIDR block format
   # Returns error when argument fails validation
   def validate_cidr_block(cidr_block)
-    parsed_cidr = NetAddr::CIDR.create(cidr_block)
-    return [parsed_cidr, nil]
+    return if NetAddr::CIDR.create(cidr_block)
   rescue NetAddr::ValidationError
-    return [nil, "Bad cidr block \"#{cidr_block}\" #{for_resource}"]
+    return "Bad cidr block \"#{cidr_block}\" #{for_resource}"
   end
 
   # Validates that at least one of the specified attributes is present


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
I expected the method `GeoEngineer::Resource#validate_cidr_block` to
behave like the other validation methods that returned an array of
errors. However the method returned an array no matter if the cidr block
was invalid or not, and the method consumer was supposed to work out if
the returned data actually signified an error or not.

I didn't like how this worked, so I rewrote it to only return an error
message if the cidr block is actually invalid.

Also added Vim swap files to the `.gitignore`
How has it been tested:
=======================
All existing tests pass.

@mentions:
==========
@grahamjenson