### PR TITLE
New: Add reset capability 

### DIFF
--- a/lib/geoengineer/utils/has_attributes.rb
+++ b/lib/geoengineer/utils/has_attributes.rb
@@ -31,28 +31,24 @@ module HasAttributes
     # this is a setter
     name = name[0...-1] if name.end_with?"="
     val = args.length == 1 ? args[0] : args
-    if val.is_a?(Proc)
-      attribute_procs[name] = val
-    else
-      attributes[name] = val
-    end
+    attribute_procs[name] = val if val.is_a?(Proc)
+    attributes[name] = val
   end
 
   def retrieve_attribute(name)
     # this is a getter
     val = if attributes.key?(name)
             attributes[name]
-          elsif attribute_procs.key?(name)
-            attribute_procs[name].call()
           else
             attribute_missing(name)
           end
-    attributes[name] = val # cache the value to override the Proc
+    return val unless val.is_a?(Proc)
+    attributes[name] = val.call() # cache the value to override the Proc
   end
 
   # For any value that has been lazily calculated, recalculate it
   def reset
-    attribute_procs.each { |name, _function| delete(name) }
+    attribute_procs.each { |name, function| attributes[name] = function }
     self
   end
 

--- a/spec/utils/has_attributes_spec.rb
+++ b/spec/utils/has_attributes_spec.rb
@@ -120,10 +120,21 @@ describe("HasAttributes") do
       example.tags = { Name: 'foo' }
       example.attribute = -> { example.tags[:Name] }
       expect(example.attribute).to eq('foo')
+      expect(example.attributes['attribute']).to eq('foo')
 
       example.tags[:Name] = 'bar'
       example.reset
+      expect(example.attributes['attribute']).to be_nil
       expect(example.attribute).to eq('bar')
+    end
+
+    it 'allows you to eagerly load all lazy attributes' do
+      example = WithAttributes.new
+      example.lazy1 = -> { "foo" }
+      example.lazy2 = -> { "bar" }
+      expect(example.attributes.count).to eq(0)
+      example.eager_load
+      expect(example.attributes.count).to eq(2)
     end
   end
 end

--- a/spec/utils/has_attributes_spec.rb
+++ b/spec/utils/has_attributes_spec.rb
@@ -114,5 +114,16 @@ describe("HasAttributes") do
       expect(x["attribute"]).to eq "asd"
       expect(x[:attribute]).to eq "asd"
     end
+
+    it 'allows you to reset already evaluated values' do
+      example = WithAttributes.new
+      example.tags = { Name: 'foo' }
+      example.attribute = -> { example.tags[:Name] }
+      expect(example.attribute).to eq('foo')
+
+      example.tags[:Name] = 'bar'
+      example.reset
+      expect(example.attribute).to eq('bar')
+    end
   end
 end

--- a/spec/utils/has_attributes_spec.rb
+++ b/spec/utils/has_attributes_spec.rb
@@ -120,11 +120,9 @@ describe("HasAttributes") do
       example.tags = { Name: 'foo' }
       example.attribute = -> { example.tags[:Name] }
       expect(example.attribute).to eq('foo')
-      expect(example.attributes['attribute']).to eq('foo')
 
       example.tags[:Name] = 'bar'
       example.reset
-      expect(example.attributes['attribute']).to be_nil
       expect(example.attribute).to eq('bar')
     end
 
@@ -132,9 +130,11 @@ describe("HasAttributes") do
       example = WithAttributes.new
       example.lazy1 = -> { "foo" }
       example.lazy2 = -> { "bar" }
-      expect(example.attributes.count).to eq(0)
+      expect(example.attributes['lazy1'].is_a?(Proc)).to eq(true)
+      expect(example.attributes['lazy2'].is_a?(Proc)).to eq(true)
       example.eager_load
-      expect(example.attributes.count).to eq(2)
+      expect(example.attributes['lazy1'].is_a?(Proc)).to eq(false)
+      expect(example.attributes['lazy2'].is_a?(Proc)).to eq(false)
     end
   end
 end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
So, I was working on a template, and I codified a default path forward
that works for most of our environments. A few however, are different,
and so I tried to override those values using a block. The resource in
question uses tags for its `_geo_id`, so I updated the `Name` tag.
After I did this, I assumed that the `_geo_id` would update, but once
it's been called, the value is static, and the lambda used to calculate
it was gone. That meant that the only way to accomodate this was to move
the value into a template parameter, which seemed like a suboptimal
solution.

Instead, I modified the logic so that we cache the Proc used to
calculate the value, and then added a reset function that allows you to
re-calculate any previously evaluated values using the original logic
with the new resource state.

How has it been tested:
=======================
Added a spec.

@mentions:
==========
@grahamjenson