### PR TITLE
Refactor: #reset

### DIFF
--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -100,6 +100,13 @@ class GeoEngineer::Resource
     _terraform_id || to_ref
   end
 
+  def reset
+    reset_attributes
+    @_remote_searched = false
+    @_remote = nil
+    self
+  end
+
   def _json_file(attribute, path)
     raise "file #{path} not found" unless File.file?(path)
 

--- a/lib/geoengineer/utils/has_attributes.rb
+++ b/lib/geoengineer/utils/has_attributes.rb
@@ -47,12 +47,12 @@ module HasAttributes
   end
 
   # For any value that has been lazily calculated, recalculate it
-  def reset
+  def reset_attributes
     attribute_procs.each { |name, function| attributes[name] = function }
     self
   end
 
-  def eager_load
+  def eager_load_attributes
     attribute_procs.each { |name, function| attributes[name] = function.call() }
     self
   end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -1,13 +1,13 @@
 require_relative './spec_helper'
 
+class GeoEngineer::RemoteResources < GeoEngineer::Resource
+  def self._fetch_remote_resources
+    [{ _geo_id: "geo_id1" }, { _geo_id: "geo_id2" }, { _geo_id: "geo_id2" }]
+  end
+end
+
 describe("GeoEngineer::Resource") do
   describe '#remote_resource' do
-    class GeoEngineer::RemoteResources < GeoEngineer::Resource
-      def self._fetch_remote_resources
-        [{ _geo_id: "geo_id1" }, { _geo_id: "geo_id2" }, { _geo_id: "geo_id2" }]
-      end
-    end
-
     it 'should return a list of resources' do
       rem_res = GeoEngineer::RemoteResources.new('rem', 'id') {
         _geo_id "geo_id1"
@@ -206,6 +206,31 @@ describe("GeoEngineer::Resource") do
       }
       resource.merge_project_tags
       expect(resource.tags.attributes).to eq({ 'c' => '3', 'd' => '4' })
+    end
+  end
+
+  describe '#reset' do
+    let(:subject) do
+      GeoEngineer::RemoteResources.new('resource', 'id') {
+        tags {
+          Name "foo"
+        }
+        _geo_id -> { tags['Name'] }
+      }
+    end
+
+    it 'resets lazily computed attributes' do
+      expect(subject._geo_id).to eq('foo')
+      subject.tags['Name'] = 'bar'
+      subject.reset
+      expect(subject._geo_id).to eq('bar')
+    end
+
+    it 'resets remote resource' do
+      expect(subject.remote_resource).to be_nil
+      subject.tags['Name'] = "geo_id1"
+      subject.reset
+      expect(subject.remote_resource).to_not be_nil
     end
   end
 

--- a/spec/utils/has_attributes_spec.rb
+++ b/spec/utils/has_attributes_spec.rb
@@ -122,7 +122,7 @@ describe("HasAttributes") do
       expect(example.attribute).to eq('foo')
 
       example.tags[:Name] = 'bar'
-      example.reset
+      example.reset_attributes
       expect(example.attribute).to eq('bar')
     end
 
@@ -132,7 +132,7 @@ describe("HasAttributes") do
       example.lazy2 = -> { "bar" }
       expect(example.attributes['lazy1'].is_a?(Proc)).to eq(true)
       expect(example.attributes['lazy2'].is_a?(Proc)).to eq(true)
-      example.eager_load
+      example.eager_load_attributes
       expect(example.attributes['lazy1'].is_a?(Proc)).to eq(false)
       expect(example.attributes['lazy2'].is_a?(Proc)).to eq(false)
     end


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
Realized that when I tried to use the `#reset` functionality in a real
world project, it didn't reset the remote resource, which meant that
_terraform_id was not refreshed, which meant that the plan still wasn't
up to date.

So I renamed the `reset` and `eager_load` to `reset_attributes` and
`eager_load_attributes`, and added a `reset` function to
`GeoEngineer::Resource`, which calls `reset_attributes` and also resets
the remote variables such that the resource re-calculates the correct
things.

How has it been tested:
=======================
Added some tests

@mentions:
==========
@grahamjenson