### PR TITLE
Refactor: Update association resources

### DIFF
--- a/lib/geoengineer/resources/aws_main_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_main_route_table_association.rb
@@ -9,6 +9,15 @@ class GeoEngineer::Resources::AwsMainRouteTableAssociation < GeoEngineer::Resour
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{vpc_id}::#{route_table_id}" } }
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'vpc_id' => vpc_id,
+      'route_table_id' => route_table_id
+    }
+    tfstate
+  end
+
   def support_tags?
     false
   end

--- a/lib/geoengineer/resources/aws_vpc_dhcp_options_association.rb
+++ b/lib/geoengineer/resources/aws_vpc_dhcp_options_association.rb
@@ -10,6 +10,15 @@ class GeoEngineer::Resources::AwsVpcDhcpOptionsAssociation < GeoEngineer::Resour
     _terraform_id -> { "#{dhcp_options_id}-#{vpc_id}" }
   }
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'vpc_id' => vpc_id,
+      'dhcp_options_id' => dhcp_options_id
+    }
+    tfstate
+  end
+
   def support_tags?
     false
   end


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
Since most of the association resources are listed/described via their
parent resource (i.e. VPC, route table, subnet, etc...), under the hood,
Terraform expects certain attributes to be present in the state file so
that it can verify that the remote resource actually exists.

So I updated the `#terraform_state` methods on the resources to add
those attributes to the state output.

How has it been tested:
=======================
By including this code in another repo and running `./geo plan`

@mentions:
==========
@grahamjenson