### PR TITLE
Fix: update aws_route fetching, caching

### DIFF
--- a/lib/geoengineer/resources/aws_route.rb
+++ b/lib/geoengineer/resources/aws_route.rb
@@ -9,6 +9,15 @@ class GeoEngineer::Resources::AwsRoute < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{route_table_id}::#{destination_cidr_block}" } }
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'route_table_id' => route_table_id,
+      'destination_cidr_block' => destination_cidr_block
+    }
+    tfstate
+  end
+
   def support_tags?
     false
   end


### PR DESCRIPTION
Type of change:
===============
- Bug fix

What changed? ... and Why:
==========================
In my original implementation, I was trying to extract the
route_table_id from the route object, forgetting that since routes are
nested, the route_table_id would be at a different level of the
response.

I've fixed that now.

How has it been tested:
=======================
Manually checking output in `irb`

@mentions:
==========
@grahamjenson