### PR TITLE
Other: Exclude auto-generated resources

### DIFF
--- a/lib/geoengineer/resources/aws_network_acl_rule.rb
+++ b/lib/geoengineer/resources/aws_network_acl_rule.rb
@@ -44,6 +44,7 @@ class GeoEngineer::Resources::AwsNetworkAclRule < GeoEngineer::Resource
       .select { |network_acl| !network_acl[:entries].empty? }
       .map { |network_acl| _generate_rules(network_acl) }
       .flatten
+      .reject { |rule| rule[:rule_number] == 32_767 }
   end
 
   def self._generate_rules(network_acl)

--- a/lib/geoengineer/resources/aws_route.rb
+++ b/lib/geoengineer/resources/aws_route.rb
@@ -30,6 +30,8 @@ class GeoEngineer::Resources::AwsRoute < GeoEngineer::Resource
       .map { |route_table| _extract_routes(route_table) }
       .flatten
       .compact
+      .reject { |route| route[:gateway_id] == "local" }
+      .reject { |route| route.key?(:destination_prefix_list_id) }
   end
 
   def self._extract_routes(route_table)


### PR DESCRIPTION
Type of change:
===============
- Clean up

What changed? ... and Why:
==========================
Routes that point to `local` are automatically created when a route
table is created, and cannot be changed.

Routes that point to a VPC endpoint are automatically created when a VPC
endpoint is associated with a route table, and cannot be modified.

NACL Rules that have the number 32767 are automatically created when a
NACL is created, and cannot be modified.

Therefore, they should not be returned by the `#_fetch_remote_resources`
method.

@mentions:
==========
@grahamjenson