### PR TITLE
New: Add aws_iam_role_policy

### DIFF
--- a/lib/geoengineer/resources/aws_iam_role_policy.rb
+++ b/lib/geoengineer/resources/aws_iam_role_policy.rb
@@ -1,0 +1,62 @@
+########################################################################
+# AwsIamRolePolicy +aws_iam_role_policy+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/iam_role_policy.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsIamRolePolicy < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :policy, :role]) }
+
+  after :initialize, -> {
+    _terraform_id -> { "#{role}:#{policy}" }
+  }
+
+  def to_terraform_state
+    tfstate = super
+    attributes = {
+      'policy' => policy,
+      'role' => role,
+      'name' => name
+    }
+
+    tfstate[:primary][:attributes] = attributes
+
+    tfstate
+  end
+
+  def support_tags?
+    false
+  end
+
+  def _policy_file(path, binding_obj = nil)
+    _json_file(:policy, path, binding_obj)
+  end
+
+  def self._fetch_remote_resources
+    AwsClients
+      .iam
+      .list_roles
+      .roles
+      .map(&:to_h)
+      .map { |role| _get_role_policies(role) }
+      .flatten
+      .compact
+      .map { |role_policy| _get_policy(role_policy) }
+  end
+
+  def self._get_role_policies(role)
+    AwsClients
+      .iam
+      .list_role_policies({ role_name: role[:role_name] })
+      .map(&:policy_names)
+      .flatten
+      .map { |policy| { role_name: role[:role_name], policy_name: policy } }
+  end
+
+  def self._get_policy(role_policy)
+    AwsClients
+      .iam
+      .get_role_policy(role_policy)
+      .to_h
+      .merge({ _terraform_id: "#{role_policy[:role_name]}:#{role_policy[:policy_name]}" })
+  end
+end

--- a/spec/resources/aws_iam_role_spec.rb
+++ b/spec/resources/aws_iam_role_spec.rb
@@ -10,24 +10,27 @@ describe "GeoEngineer::Resources::AwsIamRole" do
   describe "#_fetch_remote_resources" do
     before do
       aws_client.stub_responses(
-        :list_roles, { roles: [
-          {
-            role_name: 'Some-IAM-role',
-            arn: "arn:aws:iam::123456789123:role/some-iam-role",
-            path: "/",
-            role_id: "XXXXXXXXXXXXXXXXXXXXY",
-            create_date: Time.parse("2016-12-13 01:00:06 UTC"),
-            assume_role_policy_document: ""
-          },
-          {
-            role_name: 'Another-IAM-role',
-            arn: "arn:aws:iam::123456789123:role/another-iam-role",
-            path: "/",
-            role_id: "XXXXXXXXXXXXXXXXXXXXY",
-            create_date: Time.parse("2016-12-13 01:00:06 UTC"),
-            assume_role_policy_document: ""
-          }
-        ] }
+        :list_roles,
+        {
+          roles: [
+            {
+              role_name: 'Some-IAM-role',
+              arn: "arn:aws:iam::123456789123:role/some-iam-role",
+              path: "/",
+              role_id: "XXXXXXXXXXXXXXXXXXXXY",
+              create_date: Time.parse("2016-12-13 01:00:06 UTC"),
+              assume_role_policy_document: ""
+            },
+            {
+              role_name: 'Another-IAM-role',
+              arn: "arn:aws:iam::123456789123:role/another-iam-role",
+              path: "/",
+              role_id: "XXXXXXXXXXXXXXXXXXXXY",
+              create_date: Time.parse("2016-12-13 01:00:06 UTC"),
+              assume_role_policy_document: ""
+            }
+          ]
+        }
       )
     end
 

--- a/spec/resources/aws_iam_rule_policy_spec.rb
+++ b/spec/resources/aws_iam_rule_policy_spec.rb
@@ -1,0 +1,49 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsIamRolePolicy do
+  let(:iam_client) { AwsClients.iam }
+
+  common_resource_tests(
+    GeoEngineer::Resources::AwsIamRolePolicy,
+    'aws_iam_role_policy'
+  )
+
+  before { iam_client.setup_stubbing }
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      iam_client.stub_responses(
+        :list_roles,
+        {
+          roles: [
+            {
+              role_name: 'Some-IAM-role',
+              arn: "arn:aws:iam::123456789123:role/some-iam-role",
+              path: "/",
+              role_id: "XXXXXXXXXXXXXXXXXXXXY",
+              create_date: Time.parse("2016-12-13 01:00:06 UTC"),
+              assume_role_policy_document: ""
+            }
+          ]
+        }
+      )
+      iam_client.stub_responses(
+        :list_role_policies,
+        {
+          policy_names: ["Some-Policy-Name"],
+          is_truncated: false
+        }
+      )
+      iam_client.stub_responses(
+        :get_role_policy,
+        {
+          role_name: 'Some-IAM-role',
+          policy_name: 'Some-Policy-Name',
+          policy_document: "{ Some Policy Here... }"
+        }
+      )
+      remote_resources = GeoEngineer::Resources::AwsIamRolePolicy._fetch_remote_resources
+      expect(remote_resources.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Adding aws_iam_role_policy to Geo.

This one is a bit complex, as you first need to list all roles, then for
each role, list role policies, and then get the actual policy.

How has it been tested:
=======================
Added a spec

@mentions:
==========
@lukedemi @jackkearney