### PR TITLE
New: Update aws_redshift_cluster

### DIFF
--- a/lib/geoengineer/resources/aws_redshift_cluster.rb
+++ b/lib/geoengineer/resources/aws_redshift_cluster.rb
@@ -5,10 +5,11 @@
 # {https://www.terraform.io/docs/providers/aws/r/redshift_cluster.html#cluster_version}
 ########################################################################
 class GeoEngineer::Resources::AwsRedshiftCluster < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:cluster_identifier, :node_type]) }
   validate -> {
-    validate_required_attributes(
-      [:cluster_identifier, :node_type, :master_password, :master_username]
-    )
+    if new? && !snapshot_identifier
+      validate_required_attributes([:master_password, :master_username])
+    end
   }
   validate -> {
     validate_required_attributes([:number_of_nodes]) if self.cluster_type == 'multi-node'


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
Copied the username/password logic from `aws_db_instance` to
`aws_redshift_cluster`. This allows us to skip codifying the username
and password for a cluster if remote resource already exists.

What this means is that in practice, cluster(s) will generally be
created manually either via the AWS CLI, or the AWS Web console, and
then codified. This allows the user to sidestep the issue of having to
store sensitive data in the codifying repo.

@mentions:
==========
@lukedemi