### PR TITLE
Fix: Assign Terraform ID to remote resources...

### DIFF
--- a/lib/geoengineer/resources/aws_redshift_cluster.rb
+++ b/lib/geoengineer/resources/aws_redshift_cluster.rb
@@ -19,6 +19,11 @@ class GeoEngineer::Resources::AwsRedshiftCluster < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { cluster_identifier } }
 
   def self._fetch_remote_resources
-    AwsClients.redshift.describe_clusters.clusters.map(&:to_h)
+    AwsClients
+      .redshift
+      .describe_clusters
+      .clusters
+      .map(&:to_h)
+      .map { |cluster| cluster.merge({ _terraform_id: cluster[:cluster_identifier] }) }
   end
 end


### PR DESCRIPTION
Type of change:
===============
- Bug fix

What changed? ... and Why:
==========================
The original implementation defined `_terraform_id` on the local
resource, but didn't monkey patch the ID onto the remote resources, so
the local resource couldn't match itself with its remote counterpart.

How has it been tested:
=======================
Locally in a separate repo.