### PR TITLE
Refactor: Upate load balancer related policies

### DIFF
--- a/lib/geoengineer/resources/aws_load_balancer_policy.rb
+++ b/lib/geoengineer/resources/aws_load_balancer_policy.rb
@@ -4,30 +4,40 @@
 # {https://www.terraform.io/docs/providers/aws/r/aws_load_balancer_policy.html Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsLoadBalancerPolicy < GeoEngineer::Resource
-  validate -> { validate_required_attributes([:policy_name, :load_balancer_name]) }
+  validate -> {
+    validate_required_attributes([:policy_name, :policy_type_name, :load_balancer_name])
+  }
 
-  after :initialize, -> {
-    _terraform_id -> { "#{load_balancer_name}:#{policy_name}" }
-  }
-  after :initialize, -> {
-    _geo_id -> { "#{load_balancer_name}:#{policy_name}" }
-  }
+  after :initialize, -> { _terraform_id -> { "#{load_balancer_name}:#{policy_name}" } }
 
   def support_tags?
     false
   end
 
   def self._fetch_remote_resources
-    load_balancer_name ||= ""
-
     AwsClients
-      .elb.describe_load_balancer_policies({ load_balancer_name: load_balancer_name })
-      .policy_descriptions.map(&:to_h)
+      .elb
+      .describe_load_balancers
+      .load_balancer_descriptions
+      .map(&:to_h)
+      .map { |load_balancer| _policies_for_load_balancer(load_balancer) }
+      .flatten
+      .compact
+  end
+
+  def self._policies_for_load_balancer(load_balancer)
+    AwsClients
+      .elb
+      .describe_load_balancer_policies({ load_balancer_name: load_balancer[:load_balancer_name] })
+      .policy_descriptions
+      .map(&:to_h)
       .map do |policy|
-        {
-          '_terraform_id' => policy[:policy_name],
-          '_geo_id' => policy[:policy_name]
-        }
+        policy.merge(
+          {
+            _terraform_id: "#{load_balancer[:load_balancer_name]}:#{policy[:policy_name]}",
+            load_balancer_name: load_balancer[:load_balancer_name]
+          }
+        )
       end
   end
 end

--- a/spec/resources/aws_load_balancer_policy_spec.rb
+++ b/spec/resources/aws_load_balancer_policy_spec.rb
@@ -17,16 +17,28 @@ describe("GeoEngineer::Resources::AwsLoadBalancerPolicy") do
             {
               policy_name: "ELBSecurityPolicy-2015-05",
               policy_type_name: "SSLNegotiationPolicyType"
-            },
+            }
+          ]
+        }
+      )
+      elb_client.stub_responses(
+        :describe_load_balancers,
+        {
+          load_balancer_descriptions: [
             {
-              policy_name: "ELBSecurityPolicy-2015-05",
-              policy_type_name: "SSLNegotiationPolicyType"
+              load_balancer_name: "test",
+              backend_server_descriptions: [
+                {
+                  instance_port: 5000,
+                  policy_names: ["test"]
+                }
+              ]
             }
           ]
         }
       )
       remote_resources = GeoEngineer::Resources::AwsLoadBalancerPolicy._fetch_remote_resources
-      expect(remote_resources.length).to eq 2
+      expect(remote_resources.length).to eq 1
     end
   end
 end


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
The previous iteration of these resources:
- aws_load_balancer_policy
- aws_load_balancer_backend_server_policy

were not functional, as the `_terraform_id` didn't match that used by
Terraform, and I'm not sure the `_fetch_remote_resources` calls worked
properly. That has been fixed, and we should be able to codify these
resources now.

The one thing I will call out is that since you need to make a
relatively large number of calls for the aws_load_balancer_policy
resource.

How has it been tested:
=======================
Locally, works like a charm.

@mentions:
==========
@lukedemi