### PR TITLE
Fix: aws_lambda_alias

### DIFF
--- a/lib/geoengineer/resources/aws_lambda_alias.rb
+++ b/lib/geoengineer/resources/aws_lambda_alias.rb
@@ -4,6 +4,8 @@
 # {https://www.terraform.io/docs/providers/aws/r/lambda_alias.html Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsLambdaAlias < GeoEngineer::Resource
+  # Note: function_name here actually means function_arn, even though
+  # function_name is also a key on a lambda function.
   validate -> { validate_required_attributes([:name, :function_name, :function_version]) }
   validate -> {
     if name && (name =~ /(?!^[0-9]+$)([a-zA-Z0-9\-_]+)/).nil?
@@ -44,7 +46,7 @@ class GeoEngineer::Resources::AwsLambdaAlias < GeoEngineer::Resource
   def self._fetch_aliases(function)
     options = { function_name: function[:function_name] }
     AwsClients.lambda.list_aliases(options)[:aliases].map(&:to_h).map do |f_alias|
-      geo_id_components = [f_alias[:name], function[:function_name], f_alias[:function_version]]
+      geo_id_components = [f_alias[:name], function[:function_arn], f_alias[:function_version]]
       f_alias.merge(
         {
           _terraform_id: f_alias[:alias_arn],

--- a/spec/resources/aws_lambda_alias_spec.rb
+++ b/spec/resources/aws_lambda_alias_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-describe("GeoEngineer::Resources::AwsLambdaAlias") do
+describe GeoEngineer::Resources::AwsLambdaAlias do
   let(:aws_client) { AwsClients.lambda }
 
   before { aws_client.setup_stubbing }
@@ -12,8 +12,18 @@ describe("GeoEngineer::Resources::AwsLambdaAlias") do
       aws_client.stub_responses(
         :list_functions, {
           functions: [
-            { function_name: "foo", role: "arn:aws:iam:one", handler: "export.foo" },
-            { function_name: "bar", role: "arn:aws:iam:two", handler: "export.bar" }
+            {
+              function_name: "foo",
+              function_arn: "arn:aws:lambda:us-east-1:123:function:foo",
+              role: "arn:aws:iam:one",
+              handler: "export.foo"
+            },
+            {
+              function_name: "bar",
+              function_arn: "arn:aws:lambda:us-east-1:123:function:bar",
+              role: "arn:aws:iam:two",
+              handler: "export.bar"
+            }
           ]
         }
       )
@@ -34,6 +44,15 @@ describe("GeoEngineer::Resources::AwsLambdaAlias") do
     it 'should create list of hashes from returned AWS SDK' do
       remote_resources = GeoEngineer::Resources::AwsLambdaAlias._fetch_remote_resources
       expect(remote_resources.length).to eq(2)
+    end
+
+    it 'should match a local resource to the remote resource' do
+      subject = described_class.new('aws_lambda_alias', 'foo') {
+        name "foonew"
+        function_name "arn:aws:lambda:us-east-1:123:function:foo"
+        function_version 1
+      }
+      expect(subject.remote_resource).to_not be_nil
     end
   end
 end


### PR DESCRIPTION
Type of change:
===============
- Bug fix

What changed? ... and Why:
==========================
Last PR I was lazy. While that was also a bug, it wasn't the only bug.

Turns out the function_name attribute expecs the function_arn. I fixed
that, and added a test to ensure that it actually works as expected now.

How has it been tested:
=======================
Added a test.

@mentions:
==========
@grahamjenson