### PR TITLE
New: Allow resources to be ignored

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    geoengineer (0.1.1)
+    geoengineer (0.1.2)
       aws-sdk (~> 2.2)
       colorize (~> 0.7)
       commander (~> 4.4)
@@ -12,16 +12,18 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.3.0)
-    aws-sdk (2.6.14)
-      aws-sdk-resources (= 2.6.14)
-    aws-sdk-core (2.6.14)
+    aws-sdk (2.6.35)
+      aws-sdk-resources (= 2.6.35)
+    aws-sdk-core (2.6.35)
+      aws-sigv4 (~> 1.0)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.6.14)
-      aws-sdk-core (= 2.6.14)
+    aws-sdk-resources (2.6.35)
+      aws-sdk-core (= 2.6.35)
+    aws-sigv4 (1.0.0)
     byebug (9.0.6)
     coderay (1.1.1)
     colorize (0.8.1)
-    commander (4.4.0)
+    commander (4.4.3)
       highline (~> 1.7.2)
     diff-lcs (1.2.5)
     highline (1.7.8)
@@ -81,4 +83,4 @@ RUBY VERSION
    ruby 2.3.1p112
 
 BUNDLED WITH
-   1.13.2
+   1.13.6

--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -166,13 +166,22 @@ class GeoEngineer::Resource
   def self.fetch_remote_resources
     return @_rr_cache if @_rr_cache
     resource_hashes = _fetch_remote_resources()
-    @_rr_cache = resource_hashes.map { |res_hash| GeoEngineer::Resource.build(res_hash) }
+    @_rr_cache = resource_hashes
+                 .reject { |resource| _resources_to_ignore.include?(resource[:_geo_id]) }
+                 .map { |resource| GeoEngineer::Resource.build(resource) }
   end
 
   # This method must be implemented for each resource type
   # it must return a list of hashes with at least the key
   def self._fetch_remote_resources
     throw "NOT IMPLEMENTED ERROR for #{self.name}"
+  end
+
+  # This method allows you to specify certain remote resources that for whatever reason,
+  # cannot or should not be codified. It expects a list of `_geo_ids`, and be overriden
+  # in child classes.
+  def self._resources_to_ignore
+    []
   end
 
   def self.build(resource_hash)

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -99,6 +99,24 @@ describe("GeoEngineer::Resource") do
     end
   end
 
+  describe '#_resources_to_ignore' do
+    it 'lets you ignore certain resources' do
+      class GeoEngineer::IgnorableResources < GeoEngineer::Resource
+        def self._fetch_remote_resources
+          [{ _geo_id: "geoid1" }, { _geo_id: "geoid2" }]
+        end
+
+        def self._resources_to_ignore
+          ["geoid1"]
+        end
+      end
+
+      resources = GeoEngineer::IgnorableResources.fetch_remote_resources()
+      expect(resources.length).to eq 1
+      expect(resources[0]._geo_id).to eq "geoid2"
+    end
+  end
+
   describe '#validate_required_subresource' do
     it 'should return errors if it does not have a tag' do
       class GeoEngineer::HasSRAttrResource < GeoEngineer::Resource

--- a/spec/resources/aws_kinesis_stream_spec.rb
+++ b/spec/resources/aws_kinesis_stream_spec.rb
@@ -35,6 +35,7 @@ describe("GeoEngineer::Resources::AwsKinesisStream") do
             stream_name: "test",
             stream_arn: "arn:aws:kinesis:us-east-1:1234567890:stream/test",
             stream_status: "ACTIVE",
+            stream_creation_timestamp: Time.now,
             shards: [],
             has_more_shards: false,
             retention_period_hours: 24,


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
We've run into some issues with sensitive/difficult resources that we
don't intend to codify, and would like to remove them from planning and
status commands.

This PR adds a simple way to specify which resources should be excluded.

Alternatives considered:
- monkey patching in downstream projects (seemed hacky)
- lambda based exclusions (more flexible, but also a bit more complex)

How has it been tested:
=======================
Added a test case

@mentions:
==========
@grahamjenson @lukedemi