### PR TITLE
New: Update AWS Lambda Permission, harden method

### DIFF
--- a/lib/geoengineer/resources/aws_lambda_permission.rb
+++ b/lib/geoengineer/resources/aws_lambda_permission.rb
@@ -40,18 +40,6 @@ class GeoEngineer::Resources::AwsLambdaPermission < GeoEngineer::Resource
     nil
   end
 
-  def self._deep_symbolize_keys(obj)
-    if obj.is_a?(Hash)
-      obj.each_with_object({}) do |(key, value), hash|
-        hash[key.to_sym] = _deep_symbolize_keys(value)
-      end
-    elsif obj.is_a?(Array)
-      obj.map { |value| _deep_symbolize_keys(value) }
-    else
-      obj
-    end
-  end
-
   def self._create_permission(function)
     policy = function[:policy]
     policy[:Statement].map do |statement|
@@ -80,4 +68,26 @@ class GeoEngineer::Resources::AwsLambdaPermission < GeoEngineer::Resource
       .flatten
       .compact
   end
+
+#   def remote_resource_params
+#     params = { function_name: function_name }
+#     params[:qualifier] = qualifier if qualifier.present?
+#     policy = AwsClients.lambda.get_policy(params)&.policy
+#     return {} unless policy
+
+#     permission = _parse_policy(policy)
+#       .find { |permission| permission == principal }
+#   end
+
+#   def build_remote_resource_params(arn, entities)
+#     {
+#       name: _policy.name,
+#       _terraform_id: arn,
+#       _geo_id: _policy.name,
+#       policy_arn: arn,
+#       users: entities[:policy_users].map(&:user_name),
+#       groups: entities[:policy_groups].map(&:group_name),
+#       roles: entities[:policy_roles].map(&:role_name)
+#     }
+#   end
 end

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -6,7 +6,7 @@ class GeoEngineer::RemoteResources < GeoEngineer::Resource
   end
 end
 
-describe("GeoEngineer::Resource") do
+describe GeoEngineer::Resource do
   describe '#remote_resource' do
     it 'should return a list of resources' do
       rem_res = GeoEngineer::RemoteResources.new('rem', 'id') {
@@ -277,6 +277,44 @@ describe("GeoEngineer::Resource") do
         end
         expect(GeoEngineer::ResourceType.type_from_class_name).to eq 'resource_type'
       end
+    end
+  end
+
+  describe '#_deep_symbolize_keys' do
+    let(:simple_obj) { JSON.parse({ foo: "bar", baz: "qux" }.to_json) }
+    let(:complex_obj) do
+      JSON.parse(
+        {
+          foo: {
+            bar: {
+              baz: [
+                { qux: "quack" }
+              ]
+            }
+          },
+          bar: [
+            { foo: "bar" },
+            nil,
+            [{ baz: "qux" }],
+            1,
+            "baz"
+          ]
+        }.to_json
+      )
+    end
+
+    it "converts top level keys to symbols" do
+      expect(simple_obj.keys.include?(:foo)).to eq(false)
+      expect(simple_obj.keys.include?("foo")).to eq(true)
+      converted = described_class._deep_symbolize_keys(simple_obj)
+      expect(converted.keys.include?(:foo)).to eq(true)
+      expect(converted.keys.include?("foo")).to eq(false)
+    end
+
+    it "converts deeply nested keys to symbols" do
+      converted = described_class._deep_symbolize_keys(complex_obj)
+      expect(converted[:foo][:bar][:baz].first[:qux]).to eq("quack")
+      expect(converted[:bar].first[:foo]).to eq("bar")
     end
   end
 end

--- a/spec/resources/aws_lambda_permission_spec.rb
+++ b/spec/resources/aws_lambda_permission_spec.rb
@@ -49,5 +49,4 @@ describe GeoEngineer::Resources::AwsLambdaPermission do
       end
     end
   end
-
 end

--- a/spec/resources/aws_lambda_permission_spec.rb
+++ b/spec/resources/aws_lambda_permission_spec.rb
@@ -50,41 +50,4 @@ describe GeoEngineer::Resources::AwsLambdaPermission do
     end
   end
 
-  describe '#_deep_symbolize_keys' do
-    let(:simple_obj) { JSON.parse({ foo: "bar", baz: "qux" }.to_json) }
-    let(:complex_obj) do
-      JSON.parse(
-        {
-          foo: {
-            bar: {
-              baz: [
-                { qux: "quack" }
-              ]
-            }
-          },
-          bar: [
-            { foo: "bar" },
-            nil,
-            [{ baz: "qux" }],
-            1,
-            "baz"
-          ]
-        }.to_json
-      )
-    end
-
-    it "converts top level keys to symbols" do
-      expect(simple_obj.keys.include?(:foo)).to eq(false)
-      expect(simple_obj.keys.include?("foo")).to eq(true)
-      converted = described_class._deep_symbolize_keys(simple_obj)
-      expect(converted.keys.include?(:foo)).to eq(true)
-      expect(converted.keys.include?("foo")).to eq(false)
-    end
-
-    it "converts deeply nested keys to symbols" do
-      converted = described_class._deep_symbolize_keys(complex_obj)
-      expect(converted[:foo][:bar][:baz].first[:qux]).to eq("quack")
-      expect(converted[:bar].first[:foo]).to eq("bar")
-    end
-  end
 end


### PR DESCRIPTION
Type of change:
===============
- New feature

What changed? ... and Why:
==========================
This PR contains 2 changes:
- An update to AWS Lambda Permission, allowing it to
`_fetch_remote_as_individual`
- An update to `_resources_to_ignore` logic, which makes it more
impervious to possible end user mistakes

How has it been tested:
=======================
Added some specs, moved a couple others

@mentions:
==========
@lukedemi