### PR TITLE
New: All environments to have tags

### DIFF
--- a/lib/geoengineer/environment.rb
+++ b/lib/geoengineer/environment.rb
@@ -8,6 +8,7 @@
 ########################################################################
 class GeoEngineer::Environment
   include HasAttributes
+  include HasSubResources
   include HasResources
   include HasProjects
   include HasTemplates


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
In some of the repositories where we are using Geo, we only have
environments, and no projects. However, we still want to apply a set of
org/ProjectName tags to all of the resources. Another use case would be
auto-tagging the environment name on every resource.

We replace `merge_project_tags` with `merge_parent_tags` which then
loops through both `@environment` and `@project`.

Also had to refactor `GeoEngineer::Resource` a bit to get the total class LOC under 200 again.

How has it been tested:
=======================
Modified existing test cases to cover this new behavior.

@mentions:
==========
@grahamjenson @lukedemi