### PR TITLE
Refactor: Only log if patches loaded

### DIFF
--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -206,10 +206,9 @@ class GeoCLI
     global_options
 
     # Require any patches to the way geo works
-    begin
+    if File.file?("#{Dir.pwd}/.geo.rb")
       require_from_pwd '.geo'
-    rescue LoadError
-      puts "unable to load '.geo.rb" if @verbose
+      puts "Loaded patches from .geo.rb" if @verbose
     end
 
     # Add commands


### PR DESCRIPTION
Type of change:
===============
- Refactor

What changed? ... and Why:
==========================
Right now, every time there are no geo patches, we got an extra log
line. Seeing as the default should be no patches, I think it makes sense
to _only_ log when something non-standard is loaded.

Doing this via a begin/rescue isn't ideal, as we'd be rescueing into the
default state, where we want to no-op. Instead, we check if the file
exists, and then require the file if so.

@mentions:
==========
@lukedemi