### PR TITLE
add aws_kms_key

### DIFF
--- a/lib/geoengineer/resources/aws_kms_key.rb
+++ b/lib/geoengineer/resources/aws_kms_key.rb
@@ -1,0 +1,30 @@
+########################################################################
+# AwsKmsKey is the +aws_kms_key+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/kms_key.html}
+########################################################################
+class GeoEngineer::Resources::AwsKmsKey < GeoEngineer::Resource
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { description } }
+
+  def self._fetch_remote_resources
+    keys = AwsClients.kms.list_keys[:keys].map do |i|
+      AwsClients.kms.describe_key({ key_id: i.key_id }).key_metadata.to_h
+    end
+
+    keys.map do |k|
+      k[:_terraform_id] = k[:key_id]
+      k[:_geo_id] = k[:description]
+      k
+    end
+  end
+
+  # overwrites description field for id storage
+  def description(*_)
+    self[:description] = @id
+  end
+
+  def support_tags?
+    false
+  end
+end

--- a/lib/geoengineer/resources/aws_kms_key.rb
+++ b/lib/geoengineer/resources/aws_kms_key.rb
@@ -4,6 +4,8 @@
 # {https://www.terraform.io/docs/providers/aws/r/kms_key.html}
 ########################################################################
 class GeoEngineer::Resources::AwsKmsKey < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:description]) }
+
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { description } }
 
@@ -17,11 +19,6 @@ class GeoEngineer::Resources::AwsKmsKey < GeoEngineer::Resource
       k[:_geo_id] = k[:description]
       k
     end
-  end
-
-  # overwrites description field for id storage
-  def description(*_)
-    self[:description] = @id
   end
 
   def support_tags?

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -83,4 +83,8 @@ class AwsClients
   def self.cloudtrail
     @aws_cloudtrail ||= Aws::CloudTrail::Client.new({ stub_responses: stubbed? })
   end
+
+  def self.kms
+    @aws_kms ||= Aws::KMS::Client.new({ stub_responses: stubbed? })
+  end
 end

--- a/spec/resources/aws_kms_key_spec.rb
+++ b/spec/resources/aws_kms_key_spec.rb
@@ -1,0 +1,44 @@
+require_relative '../spec_helper'
+require 'ostruct'
+
+describe "GeoEngineer::Resources::AwsKmsKey" do
+  let(:aws_client) { AwsClients.kms }
+
+  before { aws_client.setup_stubbing }
+  common_resource_tests(GeoEngineer::Resources::AwsKmsKey, 'aws_kms_key')
+
+  let(:key_geo_id) { 'myid' }
+  let(:key_id) { 'some-key-id' }
+
+  describe '#_fetch_remote_resources' do
+    before do
+      aws_client.stub_responses(
+        :list_keys,
+        {
+          keys: [
+            { key_id: key_id }
+          ]
+        }
+      )
+      aws_client.stub_responses(
+        :describe_key,
+        {
+          key_metadata: {
+            key_id: key_id,
+            description: key_geo_id
+          }
+        }
+      )
+    end
+
+    it 'should create an array of hashes from the AWS response' do
+      resources = GeoEngineer::Resources::AwsKmsKey._fetch_remote_resources
+      expect(resources.count).to eql 1
+
+      test_key = resources.first
+
+      expect(test_key[:_geo_id]).to eql(key_geo_id)
+      expect(test_key[:_terraform_id]).to eql(key_id)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ def init_test(clazz_name)
     }
     expect(res.some_value).to eq 10
     expect(res.sub_resource.another_value).to eq 20
-    expect(res.errors.length).to_not eq 0
+    expect(res.errors.length).to_not(eq(0)) if res.class.validations.size > 1
   end
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ def init_test(clazz_name)
     }
     expect(res.some_value).to eq 10
     expect(res.sub_resource.another_value).to eq 20
-    expect(res.errors.length).to_not(eq(0)) if res.class.validations.size > 1
+    expect(res.errors.length).to_not eq 0
   end
 end
 


### PR DESCRIPTION
uses aws `description` field for `_geo_id` since this resource doesn't support tags