### PR TITLE
Parallelize state file generation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,7 @@ PATH
       colorize (~> 0.7)
       commander (~> 4.4)
       netaddr (~> 1.5)
+      parallel (~> 1.10)
 
 GEM
   remote: https://rubygems.org/
@@ -29,6 +30,7 @@ GEM
     jmespath (1.3.1)
     method_source (0.8.2)
     netaddr (1.5.1)
+    parallel (1.10.0)
     parser (2.3.1.4)
       ast (~> 2.2)
     powerpack (0.1.1)

--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'aws-sdk',           '~> 2.2'
   s.add_dependency 'commander',         '~> 4.4'
   s.add_dependency 'colorize',          '~> 0.7'
+  s.add_dependency 'parallel',          '~> 1.10'
 end


### PR DESCRIPTION
A quick performance test revealed that we could parallelize this portion
of the plan process to reduce overall time by a few seconds.

Given a laptop with 8 logical cores, I observed the following timing
differences for the modified section of code:

Optimization          | Execution time
----------------------|------------------
None (current code)   | 8.97s
4 threads             | 2.58s
6 threads             | 1.67s
8 threads             | 1.32s
16 threads            | 1.44s

Experiment revealed that setting the number of threads to the number of
logical cores gave the optimal reduction in execution time.