### PR TITLE
Increase parallelism of Terraform commands

### DIFF
--- a/lib/geoengineer/cli/terraform_commands.rb
+++ b/lib/geoengineer/cli/terraform_commands.rb
@@ -15,10 +15,15 @@ module GeoCLI::TerraformCommands
     }
   end
 
+  def terraform_parallelism
+    Parallel.processor_count * 3 # Determined through trial/error
+  end
+
   def terraform_plan
     plan_commands = [
       "cd #{@tmpdir}",
-      "terraform plan -state=#{@terraform_state_file} -out=#{@plan_file} #{@no_color}"
+      "terraform plan -parallelism=#{terraform_parallelism}" \
+      " -state=#{@terraform_state_file} -out=#{@plan_file} #{@no_color}"
     ]
     shell_exec(plan_commands.join(" && "), true)
   end
@@ -26,7 +31,8 @@ module GeoCLI::TerraformCommands
   def terraform_apply
     apply_commands = [
       "cd #{@tmpdir}",
-      "terraform apply -state=#{@terraform_state_file} #{@plan_file} #{@no_color}"
+      "terraform apply -parallelism=#{terraform_parallelism}" \
+      " -state=#{@terraform_state_file} #{@plan_file} #{@no_color}"
     ]
     shell_exec(apply_commands.join(" && "), true)
   end


### PR DESCRIPTION
Terraform exposes a `-parallelism` flag for the `plan` and `apply`
commands, allowing you to specify the degree of parallelism in the run.

We can take advantage of this to speed up these commands. Running on a
laptop with 8 cores, I observed the following improvements when
specifying the following flag for `terraform plan`:

Flag                  | Execution time (average of 3)
----------------------|------------------------------
None (current code)   | 25.5s
`-parallelism=16`     | 18.8s
`-parallelism=24`     | 15.7s
`-parallelism=32`     | 17.1s

Thus it appears that three times the number of logical cores results in
the most substantial reduction in time on average.

With this in mind, change the default parallelism used by these
Terraform commands.