### PR TITLE
Update required attribute for instance profiles from roles -> role

### DIFF
--- a/lib/geoengineer/resources/aws_iam_instance_profile.rb
+++ b/lib/geoengineer/resources/aws_iam_instance_profile.rb
@@ -4,7 +4,7 @@
 # {https://www.terraform.io/docs/providers/aws/r/iam_instance_profile.html Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsIamInstanceProfile < GeoEngineer::Resource
-  validate -> { validate_required_attributes([:name, :roles]) }
+  validate -> { validate_required_attributes([:name, :role]) }
 
   before :validation, -> { policy_arn _policy.to_ref(:arn) if _policy }
 


### PR DESCRIPTION
As of version 0.9.3, Terraform deprecates `roles` in favor of `role`.
This manifests itself with warnings like:

    * aws_iam_instance_profile.my-profile: "roles": [DEPRECATED] Use
      `role` instead. Only a single role can be passed to an IAM
      Instance Profile

Update our custom validation to expect the newer attribute name. This
breaks support for users using Terraform versions older than 0.9.3.

See https://github.com/hashicorp/terraform/pull/13130 for additional
context.