### PR TITLE
[New] Add AWS ALB to supported resources

### DIFF
--- a/lib/geoengineer/resources/aws_alb.rb
+++ b/lib/geoengineer/resources/aws_alb.rb
@@ -1,0 +1,39 @@
+########################################################################
+# AwsAlb is the +aws_alb+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/alb.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsAlb < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:subnets]) }
+  validate -> { validate_subresource_required_attributes(:access_logs, [:bucket]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id       -> { NullObject.maybe(tags)[:Name] } }
+
+  def short_type
+    "alb"
+  end
+
+  def self._merge_attributes(albs, tags)
+    albs.map do |alb|
+      alb_tags = tags.find { |desc| desc[:resource_arn] == alb[:load_balancer_arn] }
+      alb.merge(
+        {
+          _terraform_id: alb[:load_balancer_arn],
+          _geo_id: alb_tags[:tags]&.find { |tag| tag[:key] == "Name" }.dig(:value)
+        }
+      )
+    end
+  end
+
+  def self._fetch_remote_resources(provider)
+    albs = AwsClients.alb(provider).describe_load_balancers['load_balancers'].map(&:to_h)
+    tags = AwsClients.alb(provider)
+                     .describe_tags({ resource_arns: albs.map { |alb| alb[:load_balancer_arn] } })
+                     .tag_descriptions
+                     .map(&:to_h)
+
+    _merge_attributes(albs, tags)
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -24,6 +24,14 @@ class AwsClients
   end
 
   # Clients
+
+  def self.alb(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::ElasticLoadBalancingV2::Client
+    )
+  end
+
   def self.api_gateway(provider = nil)
     self.client_cache(
       provider,

--- a/spec/resources/aws_alb_spec.rb
+++ b/spec/resources/aws_alb_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAlb do
+  let(:alb_client) { AwsClients.alb }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  before { alb_client.setup_stubbing }
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      alb_client.stub_responses(
+        :describe_load_balancers,
+        {
+          load_balancers: [{ load_balancer_arn: "foo/bar-baz" }]
+        }
+      )
+      alb_client.stub_responses(
+        :describe_tags,
+        {
+          tag_descriptions: [
+            {
+              resource_arn: "foo/bar-baz",
+              tags: [{ key: "Name", value: "foo/bar-baz" }]
+            }
+          ]
+        }
+      )
+      remote_resources = GeoEngineer::Resources::AwsAlb._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
What changed? ... and Why:
==========================
Added a wrapper for ALB's and added some tests as well.

The ELB chose to enforce the name being present, which precludes the use
of the name prefix. In practice, that was fine, in part because the name
was then used as the terraform ID. With ALB's, the name is only part of
the ID, and the rest contains what looks to be some random value.

This means that the best way to keep track of the resource is via the
tags, however that means that an extra call is required to grab the
tags.

How has it been tested:
=======================
Added the usual resource tests.