### PR TITLE
[New] Add other ALB Resources

### DIFF
--- a/lib/geoengineer/resources/aws_alb_listener.rb
+++ b/lib/geoengineer/resources/aws_alb_listener.rb
@@ -1,0 +1,39 @@
+########################################################################
+# AwsAlbListener is the +aws_alb_listener+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/alb_listener.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsAlbListener < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:load_balancer_arn, :port, :default_action]) }
+  validate -> {
+    validate_subresource_required_attributes(:default_action, [:target_group_arn, :type])
+  }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id       -> { "#{load_balancer_arn}::#{port}" } }
+
+  def short_type
+    "alb_listener"
+  end
+
+  def self._merge_attributes(listener)
+    listener.merge(
+      {
+        _geo_id: "#{listener[:load_balancer_arn]}::#{listener[:port]}",
+        _terraform_id: listener[:listener_arn]
+      }
+    )
+  end
+
+  def self._fetch_remote_resources(provider)
+    albs = AwsClients.alb(provider).describe_load_balancers['load_balancers'].map(&:to_h)
+    albs.map do |alb|
+      AwsClients
+        .alb(provider)
+        .describe_listeners({ load_balancer_arn: alb[:load_balancer_arn] })
+        .listeners
+        .map(&:to_h)
+        .map { |listener| _merge_attributes(listener) }
+    end.flatten.compact
+  end
+end

--- a/lib/geoengineer/resources/aws_alb_listener_rule.rb
+++ b/lib/geoengineer/resources/aws_alb_listener_rule.rb
@@ -1,0 +1,42 @@
+########################################################################
+# AwsAlbListenerRule is the +aws_alb_listener_rule+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/alb_listener_rule.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsAlbListenerRule < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:listener_arn, :priority, :action, :condition]) }
+  validate -> {
+    validate_subresource_required_attributes(:action, [:target_group_arn, :type])
+  }
+  validate -> {
+    validate_subresource_required_attributes(:condition, [:field, :values])
+  }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id       -> { "#{listener_arn}::#{priority}" } }
+
+  def short_type
+    "alb_listener_rule"
+  end
+
+  def self._merge_attributes(rule, listener)
+    rule.merge(
+      {
+        _geo_id: "#{listener[:listener_arn]}::#{rule[:priority]}",
+        _terraform_id: rule[:rule_arn]
+      }
+    )
+  end
+
+  def self._fetch_remote_resources(provider)
+    listeners = GeoEngineer::Resources::AwsAlbListener._fetch_remote_resources(provider)
+    listeners.map do |listener|
+      AwsClients
+        .alb(provider)
+        .describe_rules({ listener_arn: listener[:listener_arn] })
+        .rules
+        .map(&:to_h)
+        .map { |rule| _merge_attributes(rule, listener) }
+    end.flatten.compact
+  end
+end

--- a/lib/geoengineer/resources/aws_alb_target_group.rb
+++ b/lib/geoengineer/resources/aws_alb_target_group.rb
@@ -1,0 +1,30 @@
+########################################################################
+# AwsAlbTargetGroup is the +aws_alb_target_group+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/alb_target_group.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsAlbTargetGroup < GeoEngineer::Resource
+  validate -> {
+    validate_required_attributes([:port, :protocol, :vpc_id])
+  }
+  validate -> { validate_subresource_required_attributes(:stickiness, [:type]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id       -> { "#{vpc_id}::#{protocol}::#{port}" } }
+
+  def short_type
+    "alb_target_group"
+  end
+
+  def self._fetch_remote_resources(provider)
+    target_groups = AwsClients.alb(provider).describe_target_groups.target_groups.map(&:to_h)
+    target_groups.map do |group|
+      group.merge(
+        {
+          _geo_id: "#{group[:vpc_id]}::#{group[:protocol]}::#{group[:port]}",
+          _terraform_id: group[:target_group_arn]
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -24,6 +24,14 @@ class AwsClients
   end
 
   # Clients
+
+  def self.alb(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::ElasticLoadBalancingV2::Client
+    )
+  end
+
   def self.api_gateway(provider = nil)
     self.client_cache(
       provider,

--- a/spec/resources/aws_alb_listener_rule_spec.rb
+++ b/spec/resources/aws_alb_listener_rule_spec.rb
@@ -1,0 +1,45 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAlbListenerRule do
+  let(:alb_client) { AwsClients.alb }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  before { alb_client.setup_stubbing }
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      alb_client.stub_responses(
+        :describe_load_balancers,
+        {
+          load_balancers: [{ load_balancer_arn: "foo/bar-baz" }]
+        }
+      )
+      alb_client.stub_responses(
+        :describe_listeners,
+        {
+          listeners: [
+            {
+              load_balancer_arn: "foo/bar-baz",
+              listener_arn: "listener/foo/bar-baz",
+              port: 443
+            }
+          ]
+        }
+      )
+      alb_client.stub_responses(
+        :describe_rules,
+        {
+          rules: [
+            {
+              rule_arn: "rule/foo/bar-baz",
+              priority: "69"
+            }
+          ]
+        }
+      )
+      remote_resources = GeoEngineer::Resources::AwsAlbListenerRule._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 1
+    end
+  end
+end

--- a/spec/resources/aws_alb_listener_spec.rb
+++ b/spec/resources/aws_alb_listener_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAlbListener do
+  let(:alb_client) { AwsClients.alb }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  before { alb_client.setup_stubbing }
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      alb_client.stub_responses(
+        :describe_load_balancers,
+        {
+          load_balancers: [{ load_balancer_arn: "foo/bar-baz" }]
+        }
+      )
+      alb_client.stub_responses(
+        :describe_listeners,
+        {
+          listeners: [
+            {
+              load_balancer_arn: "foo/bar-baz",
+              port: 443
+            }
+          ]
+        }
+      )
+      remote_resources = GeoEngineer::Resources::AwsAlbListener._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 1
+    end
+  end
+end

--- a/spec/resources/aws_alb_target_group_spec.rb
+++ b/spec/resources/aws_alb_target_group_spec.rb
@@ -1,0 +1,35 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAlbTargetGroup do
+  let(:alb_client) { AwsClients.alb }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  before { alb_client.setup_stubbing }
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      alb_client.stub_responses(
+        :describe_target_groups,
+        {
+          target_groups: [
+            {
+              target_group_arn: "targetgroup/foo/bar-baz",
+              port: 443,
+              protocol: "HTTPS",
+              vpc_id: "vpc-1"
+            },
+            {
+              target_group_arn: "targetgroup/foo/test-test",
+              port: 80,
+              protocol: "HTTP",
+              vpc_id: "vpc-1"
+            }
+          ]
+        }
+      )
+      remote_resources = GeoEngineer::Resources::AwsAlbTargetGroup._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
What changed? ... and Why:
==========================
Add ability to codify listeners, rules, and target groups.

Opted not to codify the target group attachment, as that "resource" only
exists there is an instance described via the target health endpoint.

Also, I imagine those attachments will change too frequently to provide
much value being codified.

How has it been tested:
=======================
Added the usual tests.