### PR TITLE
[fix] Handle attributes named 'type' that clash with base functions

### DIFF
--- a/lib/geoengineer/resources/aws_customer_gateway.rb
+++ b/lib/geoengineer/resources/aws_customer_gateway.rb
@@ -10,6 +10,10 @@ class GeoEngineer::Resources::AwsCustomerGateway < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
 
+  def gateway_type(val=nil)
+    val ? self["type"] = val : self["type"]
+  end
+
   def self._fetch_remote_resources(provider)
     AwsClients.ec2(provider)
               .describe_customer_gateways['customer_gateways']

--- a/lib/geoengineer/resources/aws_route53_record.rb
+++ b/lib/geoengineer/resources/aws_route53_record.rb
@@ -13,7 +13,11 @@ class GeoEngineer::Resources::AwsRoute53Record < GeoEngineer::Resource
     end
   }
 
-  after :initialize, -> { _terraform_id -> { "#{zone_id}_#{name}_#{type}" } }
+  after :initialize, -> { _terraform_id -> { "#{zone_id}_#{name}_#{record_type}" } }
+
+  def record_type(val=nil)
+    val ? self["type"] = val : self["type"]
+  end
 
   def support_tags?
     false

--- a/lib/geoengineer/resources/aws_vpn_connection.rb
+++ b/lib/geoengineer/resources/aws_vpn_connection.rb
@@ -10,6 +10,10 @@ class GeoEngineer::Resources::AwsVpnConnection < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
 
+  def vpn_type(val=nil)
+    val ? self["type"] = val : self["type"]
+  end
+
   def self._fetch_remote_resources(provider)
     AwsClients
       .ec2(provider)


### PR DESCRIPTION
The `GeoEngineer::Resource` base class defines a function named `type` which
returns the reource type. This however clashes with resources that have an
attribute named `type`. Currently, this happens with 3 objects:

  * `aws_customer_gateway`
  * `aws_route53_record`
  * `aws_vpn_connection`

The problem that happens is an error setting the `type` attribute. It will throw
an `ArgumentError` saying `wrong number of attributes (1 given, 0 expected)`. On
all, the `type` is required, where not setting it would then result in a
validation error.

This simply adds function for each that will allow setting the value in the
attribute hash.