### PR TITLE
Add aws_network_interface resource

### DIFF
--- a/lib/geoengineer/resources/aws_network_interface.rb
+++ b/lib/geoengineer/resources/aws_network_interface.rb
@@ -1,0 +1,22 @@
+########################################################################
+# AwsNetworkInterface is the +aws_network_interface+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/network_interface.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsNetworkInterface < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:subnet_id]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id       -> { Array(private_ips).join(',') } }
+
+  def self._fetch_remote_resources(provider)
+    interfaces = AwsClients.ec2(provider).describe_network_interfaces
+
+    interfaces['network_interfaces'].map(&:to_h).map do |interface|
+      addresses = interface[:private_ip_addresses].collect { |a| a[:private_ip_address] }
+      interface[:_terraform_id] = interface[:network_interface_id]
+      interface[:_geo_id] = addresses.join(',')
+      interface
+    end
+  end
+end

--- a/spec/resources/aws_network_interface_spec.rb
+++ b/spec/resources/aws_network_interface_spec.rb
@@ -1,0 +1,32 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsNetworkInterface do
+  let(:aws_client) { AwsClients.ec2 }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe '#_fetch_remote_resources' do
+    before do
+      aws_client.stub_responses(
+        :describe_network_interfaces, {
+          network_interfaces: [
+            { network_interface_id: "eni-xxxxxxxx", subnet_id: 'subnet-123456',
+              private_ip_addresses: [{ private_ip_address: '99.0.0.0' },
+                                     { private_ip_address: '99.0.0.1' }] },
+            { network_interface_id: "eni-xxxxxxxy", subnet_id: 'subnet-123456',
+              private_ip_addresses: [{ private_ip_address: '99.0.0.2' }] }
+          ]
+        }
+      )
+    end
+
+    it 'should create an array of hashes from the AWS response' do
+      resources = GeoEngineer::Resources::AwsNetworkInterface._fetch_remote_resources(nil)
+      expect(resources.count).to eql 2
+
+      test_interface = resources.first
+      expect(test_interface[:_terraform_id]).to eql "eni-xxxxxxxx"
+      expect(test_interface[:_geo_id]).to eql "99.0.0.0,99.0.0.1"
+    end
+  end
+end


### PR DESCRIPTION
This adds the Terraform `aws_network_interface` resource to create ENI's within
EC2. This allows specifying a single or multiple private IP addresses to an interface that can attached a machine to manage its internal IP address.