### PR TITLE
Additional updates to support Route53 zones and records.

### DIFF
--- a/lib/geoengineer/resources/aws_route53_record.rb
+++ b/lib/geoengineer/resources/aws_route53_record.rb
@@ -3,6 +3,8 @@
 #
 # {https://www.terraform.io/docs/providers/aws/r/route53_record.html Terraform Docs}
 ########################################################################
+
+# Note: Currently, 'name' must be the fully qualified domain name.
 class GeoEngineer::Resources::AwsRoute53Record < GeoEngineer::Resource
   validate -> { validate_required_attributes([:zone_id, :name, :type]) }
   validate -> { validate_required_attributes([:ttl, :records]) unless self.alias }
@@ -13,10 +15,25 @@ class GeoEngineer::Resources::AwsRoute53Record < GeoEngineer::Resource
     end
   }
 
-  after :initialize, -> { _terraform_id -> { "#{zone_id}_#{name}_#{record_type}" } }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{zone_id}_#{self.name.downcase}_#{record_type}" } }
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'id' => _terraform_id,
+      'name' => name,
+      'type' => record_type
+    }
+    tfstate
+  end
 
   def record_type(val=nil)
     val ? self["type"] = val : self["type"]
+  end
+
+  def fqdn
+    self["name"].downcase
   end
 
   def support_tags?
@@ -32,9 +49,34 @@ class GeoEngineer::Resources::AwsRoute53Record < GeoEngineer::Resource
   end
 
   def self._fetch_records_for_zone(provider, zone)
-    records = AwsClients.route53(provider).list_resource_record_sets({ hosted_zone_id: zone[:id] })
-    records.resource_record_sets.map(&:to_h).map do |record|
-      record.merge({ _terraform_id: "#{record[:zone_id]}_#{record[:name]}_#{record[:type]}" })
+    zone_id = zone[:id].gsub(/^\/hostedzone\//, '')
+    response = AwsClients.route53(provider).list_resource_record_sets({ hosted_zone_id: zone_id })
+
+    records = []
+    response.each do |page|
+      records += page.resource_record_sets.map(&:to_h).map do |record|
+        name = _fetch_name(record, zone)
+        id = "#{zone_id}_#{name}_#{record[:type]}"
+        record.merge({ fqdn: name, _terraform_id: id, _geo_id: id })
+      end
     end
+
+    records
   end
+
+  def self._fetch_name(record, zone)
+    # Need to trim the trailing dot, as well as convert ASCII 42 (Octal 52) to
+    # the wildcard star. Route53 uses that for wildcard records.
+    name = record[:name].downcase.gsub(/\.$/, '').gsub(/^\\052/, '*')
+    zone_name = zone[:name].gsub(/\.$/, '')
+    if name !~ /#{zone_name}$/
+      if name.empty?
+        name = zone_name
+      else
+        name = "#{name}.#{zone_name}"
+      end
+    end
+    name
+  end
+
 end


### PR DESCRIPTION
This adds additional fixes to Route53 handling, including proper handling for
zone FQDN handling to include the trailing dot in the terraform id, as well as
outputting the terraform state to handle importing zones attached to multiple
VPCs.

Also a number of updates to the record handling, including updating it to work
as remote resource and populate with existing data. It'll properly retrieve all
records across multiple pages, and also has necessary handling for trailing dot
handling.

On record values, Route53 seems a bit inconsistent with its trailing dot
handling. It seems to work with or without, however doesn't massage the data on
its end.