### PR TITLE
Terraform 0.10+ requires a "terraform init" before plan

### DIFF
--- a/lib/geoengineer/cli/terraform_commands.rb
+++ b/lib/geoengineer/cli/terraform_commands.rb
@@ -22,6 +22,7 @@ module GeoCLI::TerraformCommands
   def terraform_plan
     plan_commands = [
       "cd #{@tmpdir}",
+      "terraform init",
       "terraform refresh",
       "terraform plan --refresh=false -parallelism=#{terraform_parallelism}" \
       " -state=#{@terraform_state_file} -out=#{@plan_file} #{@no_color}"


### PR DESCRIPTION
As of 0.10, Terraform now requires a `terraform init` step before plan so it can fetch the `aws` provider plugin.

This is a result of them forking out the providers into separate repositories; they're no longer included in the `terraform` binary itself.

<https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md#0100-august-2-2017>

Cheers,

Anthony