### PR TITLE
[FIX] Update ALB Resources

### DIFF
--- a/lib/geoengineer/resources/aws_alb.rb
+++ b/lib/geoengineer/resources/aws_alb.rb
@@ -29,6 +29,8 @@ class GeoEngineer::Resources::AwsAlb < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     albs = AwsClients.alb(provider).describe_load_balancers['load_balancers'].map(&:to_h)
+    return [] if albs.empty?
+
     tags = AwsClients.alb(provider)
                      .describe_tags({ resource_arns: albs.map { |alb| alb[:load_balancer_arn] } })
                      .tag_descriptions

--- a/lib/geoengineer/resources/aws_alb_listener.rb
+++ b/lib/geoengineer/resources/aws_alb_listener.rb
@@ -16,6 +16,10 @@ class GeoEngineer::Resources::AwsAlbListener < GeoEngineer::Resource
     "alb_listener"
   end
 
+  def support_tags?
+    false
+  end
+
   def self._merge_attributes(listener)
     listener.merge(
       {

--- a/lib/geoengineer/resources/aws_alb_target_group.rb
+++ b/lib/geoengineer/resources/aws_alb_target_group.rb
@@ -10,21 +10,34 @@ class GeoEngineer::Resources::AwsAlbTargetGroup < GeoEngineer::Resource
   validate -> { validate_subresource_required_attributes(:stickiness, [:type]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id       -> { "#{vpc_id}::#{protocol}::#{port}" } }
+  after :initialize, -> { _geo_id       -> { NullObject.maybe(tags)[:Name] } }
 
   def short_type
     "alb_target_group"
   end
 
-  def self._fetch_remote_resources(provider)
-    target_groups = AwsClients.alb(provider).describe_target_groups.target_groups.map(&:to_h)
-    target_groups.map do |group|
-      group.merge(
+  def self._merge_attributes(target_groups, tags)
+    target_groups.map do |target_group|
+      target_group_tags = tags.find do |desc|
+        desc[:resource_arn] == target_group[:target_group_arn]
+      end
+
+      target_group.merge(
         {
-          _geo_id: "#{group[:vpc_id]}::#{group[:protocol]}::#{group[:port]}",
-          _terraform_id: group[:target_group_arn]
+          _terraform_id: target_group[:target_group_arn],
+          _geo_id: target_group_tags[:tags]&.find { |tag| tag[:key] == "Name" }.dig(:value)
         }
       )
     end
+  end
+
+  def self._fetch_remote_resources(provider)
+    target_groups = AwsClients.alb(provider).describe_target_groups.target_groups
+    tags = AwsClients.alb(provider)
+                     .describe_tags({ resource_arns: target_groups.map(&:target_group_arn) })
+                     .tag_descriptions
+                     .map(&:to_h)
+
+    _merge_attributes(target_groups.map(&:to_h), tags)
   end
 end

--- a/spec/resources/aws_alb_listener_spec.rb
+++ b/spec/resources/aws_alb_listener_spec.rb
@@ -12,7 +12,12 @@ describe GeoEngineer::Resources::AwsAlbListener do
       alb_client.stub_responses(
         :describe_load_balancers,
         {
-          load_balancers: [{ load_balancer_arn: "foo/bar-baz" }]
+          load_balancers: [
+            {
+              load_balancer_arn: "foo/bar-baz",
+              load_balancer_name: "foo-bar-baz"
+            }
+          ]
         }
       )
       alb_client.stub_responses(

--- a/spec/resources/aws_alb_spec.rb
+++ b/spec/resources/aws_alb_spec.rb
@@ -29,5 +29,12 @@ describe GeoEngineer::Resources::AwsAlb do
       remote_resources = GeoEngineer::Resources::AwsAlb._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 1
     end
+
+    it "should work if no ALB's exist" do
+      alb_client.stub_responses(:describe_load_balancers, { load_balancers: [] })
+
+      remote_resources = GeoEngineer::Resources::AwsAlb._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 0
+    end
   end
 end

--- a/spec/resources/aws_alb_target_group_spec.rb
+++ b/spec/resources/aws_alb_target_group_spec.rb
@@ -28,6 +28,21 @@ describe GeoEngineer::Resources::AwsAlbTargetGroup do
           ]
         }
       )
+      alb_client.stub_responses(
+        :describe_tags,
+        {
+          tag_descriptions: [
+            {
+              resource_arn: "targetgroup/foo/bar-baz",
+              tags: [{ key: "Name", value: "foo/bar-baz" }]
+            },
+            {
+              resource_arn: "targetgroup/foo/test-test",
+              tags: [{ key: "Name", value: "foo/test-test" }]
+            }
+          ]
+        }
+      )
       remote_resources = GeoEngineer::Resources::AwsAlbTargetGroup._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 2
     end

--- a/spec/resources/aws_alb_target_group_spec.rb
+++ b/spec/resources/aws_alb_target_group_spec.rb
@@ -46,5 +46,12 @@ describe GeoEngineer::Resources::AwsAlbTargetGroup do
       remote_resources = GeoEngineer::Resources::AwsAlbTargetGroup._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 2
     end
+
+    it "should work if no ALB's exist" do
+      alb_client.stub_responses(:describe_target_groups, { target_groups: [] })
+
+      remote_resources = GeoEngineer::Resources::AwsAlbTargetGroup._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 0
+    end
   end
 end


### PR DESCRIPTION
ALB Listeners don't support tags, so add `supports_tags?` => `false`

The `_geo_id` for ALB Target groups was quite naive, and would have
quickly run into conflicts. Since the resource supports tags, we'll use
that instead. Also updates the tests accordingly.