### PR TITLE
Updates route53_zone to handle differentiating public/private zones.

### DIFF
--- a/lib/geoengineer/resources/aws_route53_zone.rb
+++ b/lib/geoengineer/resources/aws_route53_zone.rb
@@ -7,7 +7,11 @@ class GeoEngineer::Resources::AwsRoute53Zone < GeoEngineer::Resource
   validate -> { validate_required_attributes([:name]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{self.name}." } }
+  after :initialize, -> { _geo_id -> { "#{self._public_or_private}-#{self.name}." } }
+
+  def _public_or_private
+    self.vpc_id.nil? ? 'public' : self.vpc_id
+  end
 
   def to_terraform_state
     tfstate = super
@@ -20,14 +24,25 @@ class GeoEngineer::Resources::AwsRoute53Zone < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    hosted_zones = AwsClients.route53(provider).list_hosted_zones.hosted_zones.map(&:to_h)
+    _fetch_zones(provider).map { |zone| _generate_remote_zone(provider, zone) }
+  end
 
-    hosted_zones.map do |zone|
-      zone[:id] = zone[:id].gsub(%r{^/hostedzone/}, '')
-      zone[:_terraform_id] = zone[:id]
-      zone[:_geo_id]       = zone[:name]
-      zone[:zone_id] = zone[:id]
-      zone
-    end
+  def self._fetch_zones(provider)
+    AwsClients.route53(provider).list_hosted_zones.hosted_zones.map(&:to_h)
+  end
+
+  def self._generate_remote_zone(provider, zone)
+    is_private_zone = zone.dig(:config, :private_zone) || false
+
+    zone[:id] = zone[:id].gsub(%r{^/hostedzone/}, '')
+    zone[:zone_id]       = zone[:id]
+    zone[:_terraform_id] = zone[:id]
+    zone[:vpc_id]        = _get_zone_vpc_id(provider, zone[:id]) if is_private_zone
+    zone[:_geo_id]       = "#{is_private_zone ? zone[:vpc_id] : 'public'}-#{zone[:name]}"
+    zone
+  end
+
+  def self._get_zone_vpc_id(provider, zone_id)
+    AwsClients.route53(provider).get_hosted_zone({ id: zone_id }).to_h[:vp_cs].first[:vpc_id]
   end
 end

--- a/spec/resources/aws_route53_zone_spec.rb
+++ b/spec/resources/aws_route53_zone_spec.rb
@@ -11,7 +11,10 @@ describe(GeoEngineer::Resources::AwsRoute53Zone) do
       aws_client.stub_responses(
         :list_hosted_zones, {
           hosted_zones: [
-            { id: '123',  name: "testzone", caller_reference: "test" },
+            { id: '123',  name: "testzone", caller_reference: "test",
+              config: { private_zone: false } },
+            { id: '124',  name: "testzone", caller_reference: "test",
+              config: { private_zone: true } },
             { id: '1234', name: "anothertestzone", caller_reference: "test" }
           ],
           is_truncated: false,
@@ -19,15 +22,28 @@ describe(GeoEngineer::Resources::AwsRoute53Zone) do
           marker: "foo"
         }
       )
+
+      aws_client.stub_responses(
+        :get_hosted_zone, {
+          hosted_zone: {
+            id: '124', name: "testzone", caller_reference: "test"
+          },
+          vp_cs: [{ vpc_id: "myvpc" }]
+        }
+      )
     end
 
     it 'should create an array of hashes from the AWS response' do
       resources = GeoEngineer::Resources::AwsRoute53Zone._fetch_remote_resources(nil)
-      expect(resources.count).to eql(2)
+      expect(resources.count).to eql(3)
 
       testzone = resources.first
       expect(testzone[:_terraform_id]).to eql('123')
-      expect(testzone[:_geo_id]).to eql('testzone')
+      expect(testzone[:_geo_id]).to eql('public-testzone')
+
+      testzone = resources[1]
+      expect(testzone[:_terraform_id]).to eql('124')
+      expect(testzone[:_geo_id]).to eql('myvpc-testzone')
     end
   end
 end


### PR DESCRIPTION
This fixes `aws_route53_zone` to include whether the zone is public or private
one belonging to a VPC in the `geo_id`. This helps in cases where the same
domain has two or more zones, such as a public one and a private one internal to
a VPC.