### PR TITLE
Updates AwsNatGateway resource and specs

### DIFF
--- a/spec/resources/aws_nat_gateway_spec.rb
+++ b/spec/resources/aws_nat_gateway_spec.rb
@@ -12,12 +12,14 @@ describe(GeoEngineer::Resources::AwsNatGateway) do
             {
               nat_gateway_id: 'name1',
               subnet_id: 's1',
-              nat_gateway_addresses: [{ allocation_id: 'a1' }]
+              nat_gateway_addresses: [{ allocation_id: 'a1' }],
+              tags: [{ key: 'Name', value: 'name-tag-1' }]
             },
             {
               nat_gateway_id: 'name2',
               subnet_id: 's2',
-              nat_gateway_addresses: [{ allocation_id: 'a2' }]
+              nat_gateway_addresses: [{ allocation_id: 'a2' }],
+              tags: [{ key: 'Name', value: 'name-tag-2' }]
             }
           ]
         }


### PR DESCRIPTION
AWS recently added tag support for NAT gateways. This PR forces NAT gateways to be declared using the Name tag as the `_geo_id` for NAT gateways