### PR TITLE
Ignore terminated EMR clusters

### DIFF
--- a/lib/geoengineer/resources/aws_emr_cluster.rb
+++ b/lib/geoengineer/resources/aws_emr_cluster.rb
@@ -4,6 +4,8 @@
 # {https://www.terraform.io/docs/providers/aws/r/emr_cluster.html}
 ########################################################################
 class GeoEngineer::Resources::AwsEmrCluster < GeoEngineer::Resource
+  TERMINATED_CLUSTER_STATES = %w(TERMINATING TERMINATED TERMINATED_WITH_ERRORS).freeze
+
   validate -> { validate_required_attributes([:name]) }
   validate -> { validate_has_tag(:Name) }
 
@@ -11,10 +13,16 @@ class GeoEngineer::Resources::AwsEmrCluster < GeoEngineer::Resource
   after :initialize, -> { _geo_id -> { name } }
 
   def self._fetch_remote_resources(provider)
-    AwsClients.emr(provider).list_clusters['clusters'].map(&:to_h).map do |cluster|
+    clusters = AwsClients.emr(provider).list_clusters['clusters'].map(&:to_h).map do |cluster|
       cluster[:_terraform_id] = cluster[:id]
       cluster[:_geo_id] = cluster[:name]
       cluster
+    end
+
+    # AWS allows you to create multiple clusters with the same name if the
+    # existing cluster is already terminated. Filter them out
+    clusters.reject do |cluster|
+      TERMINATED_CLUSTER_STATES.include?(cluster.fetch(:status, {})[:state])
     end
   end
 end

--- a/spec/resources/aws_emr_cluster_spec.rb
+++ b/spec/resources/aws_emr_cluster_spec.rb
@@ -8,7 +8,7 @@ describe GeoEngineer::Resources::AwsEmrCluster do
   before { aws_client.setup_stubbing }
 
   describe '#_fetch_remote_resources' do
-    it 'should create a list of hashes from AWS SDK' do
+    it 'creates a list of hashes from AWS SDK' do
       aws_client.stub_responses(
         :list_clusters, { clusters: [{ id: 'some-id', name: 'some-name' }] }
       )
@@ -17,6 +17,33 @@ describe GeoEngineer::Resources::AwsEmrCluster do
       expect(remote_resources.length).to eq 1
       remote_resource = remote_resources.first
       expect(remote_resource[:id]).to eq 'some-id'
+      expect(remote_resource[:name]).to eq 'some-name'
+    end
+
+    it 'ignores terminated clusters' do
+      aws_client.stub_responses(
+        :list_clusters,
+        {
+          clusters: [
+            { id: 'j-XXXXXXXXXXXX1',
+              name: 'some-name' },
+            { id: 'j-XXXXXXXXXXXX2',
+              name: 'some-name',
+              status: { state: 'TERMINATED' } },
+            { id: 'j-XXXXXXXXXXXX3',
+              name: 'some-name',
+              status: { state: 'TERMINATED_WITH_ERRORS' } },
+            { id: 'j-XXXXXXXXXXXX4',
+              name: 'some-name',
+              status: { state: 'TERMINATING' } }
+          ]
+        }
+      )
+
+      remote_resources = GeoEngineer::Resources::AwsEmrCluster._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 1
+      remote_resource = remote_resources.first
+      expect(remote_resource[:id]).to eq 'j-XXXXXXXXXXXX1'
       expect(remote_resource[:name]).to eq 'some-name'
     end
   end


### PR DESCRIPTION
AWS allows you to create multiple clusters with the same name if the existing cluster is already terminated. Filter out terminated clusters so that Geo's resource finding doesn't fail when setting up and tearing down multiple clusters quickly.

This is especially necessary since AWS will keep these terminated clusters around for potentially weeks (looking around online, there is no officially documented timeframe).
