### PR TITLE
Utilize AWS NAT Gateway tagging

### DIFF
--- a/lib/geoengineer/resources/aws_nat_gateway.rb
+++ b/lib/geoengineer/resources/aws_nat_gateway.rb
@@ -5,24 +5,19 @@
 ########################################################################
 class GeoEngineer::Resources::AwsNatGateway < GeoEngineer::Resource
   validate -> { validate_required_attributes(%i(subnet_id allocation_id)) }
+  validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{allocation_id}::#{subnet_id}" } }
-
-  def support_tags?
-    false
-  end
+  after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
 
   def self._fetch_remote_resources(provider)
     AwsClients.ec2(provider).describe_nat_gateways['nat_gateways'].map(&:to_h).map do |gateway|
-      # AWS SDK has `nat_gateway_addresses` as an array, but you should only be able to
-      # have exactly 1 elastic IP association. This logic should cover the bases...
-      allocation = gateway[:nat_gateway_addresses].find { |addr| addr.key?(:allocation_id) }
-
-      gateway[:_terraform_id] = gateway[:nat_gateway_id]
-      gateway[:_geo_id] = "#{allocation[:allocation_id]}::#{gateway[:subnet_id]}"
-
-      gateway
+      gateway.merge(
+        {
+          _terraform_id: gateway[:nat_gateway_id],
+          _geo_id: gateway[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
+        }
+      )
     end
   end
 end

--- a/spec/resources/aws_nat_gateway_spec.rb
+++ b/spec/resources/aws_nat_gateway_spec.rb
@@ -12,12 +12,14 @@ describe(GeoEngineer::Resources::AwsNatGateway) do
             {
               nat_gateway_id: 'name1',
               subnet_id: 's1',
-              nat_gateway_addresses: [{ allocation_id: 'a1' }]
+              nat_gateway_addresses: [{ allocation_id: 'a1' }],
+              tags: [{ key: 'Name', value: 'tag_name1' }]
             },
             {
               nat_gateway_id: 'name2',
               subnet_id: 's2',
-              nat_gateway_addresses: [{ allocation_id: 'a2' }]
+              nat_gateway_addresses: [{ allocation_id: 'a2' }],
+              tags: [{ key: 'Name', value: 'tag_name2' }]
             }
           ]
         }


### PR DESCRIPTION
AWS NAT Gateway supports tagging, so we can use name tag to identify AWS NAT Gateway. However, this change breaks existing AWS NAT Gateway set up in geoengineer unless name tag is manually added.