### PR TITLE
[Hack] dynamodb TTLs not supported for updating

### DIFF
--- a/lib/geoengineer/resources/aws_dynamodb_table.rb
+++ b/lib/geoengineer/resources/aws_dynamodb_table.rb
@@ -12,6 +12,18 @@ class GeoEngineer::Resources::AwsDynamodbTable < GeoEngineer::Resource
     false
   end
 
+  def to_terraform_state
+    tfstate = super
+    return tfstate unless self.ttl
+
+    tfstate[:primary][:attributes] = {
+      "ttl.#" => "1",
+      "ttl.1794544261.attribute_name": ttl.attribute_name.to_s,
+      "ttl.1794544261.enabled": ttl.enabled.to_s
+    }
+    tfstate
+  end
+
   def self._fetch_remote_resources(provider)
     AwsClients.dynamo(provider).list_tables['table_names'].map { |name|
       {

--- a/lib/geoengineer/resources/aws_dynamodb_table.rb
+++ b/lib/geoengineer/resources/aws_dynamodb_table.rb
@@ -18,8 +18,9 @@ class GeoEngineer::Resources::AwsDynamodbTable < GeoEngineer::Resource
 
     tfstate[:primary][:attributes] = {
       "ttl.#" => "1",
-      "ttl.1794544261.attribute_name": ttl.attribute_name.to_s,
-      "ttl.1794544261.enabled": ttl.enabled.to_s
+      # random number determined by fair dice roll, used to flatten list to hash
+      "ttl.0000000006.attribute_name": ttl.attribute_name.to_s,
+      "ttl.0000000006.enabled": ttl.enabled.to_s
     }
     tfstate
   end

--- a/lib/geoengineer/templates/json_rest_api.rb
+++ b/lib/geoengineer/templates/json_rest_api.rb
@@ -68,7 +68,7 @@ class GeoEngineer::Templates::JsonRestApi < GeoEngineer::Template
         _rest_api rest_api
         _resource api_resource
         http_method http_method
-        self["type"] = "AWS"
+        self["type"] = "AWS_PROXY"
         integration_http_method "POST" # ALWAYS POST TO LAMBDAS
         uri "#{api_gateway_arn}:lambda:path/2015-03-31/#{invocation_arn}"
       }


### PR DESCRIPTION
Calculating the TTL is very expensive due to the AWS API, so instead of calculating it, we will just not support updating it till terraform refresh works for it. 

Linked issue https://github.com/hashicorp/terraform/issues/16766

Also: minor fix for rest_api template.