### PR TITLE
[FIX] Update the RDS Cluster Param Group

### DIFF
--- a/lib/geoengineer/resources/aws_rds_cluster_parameter_group.rb
+++ b/lib/geoengineer/resources/aws_rds_cluster_parameter_group.rb
@@ -14,18 +14,21 @@ class GeoEngineer::Resources::AwsRdsClusterParameterGroup < GeoEngineer::Resourc
     "rdspg"
   end
 
-  def self._is_aurora?(pg)
-    pg.key?(:db_parameter_group_family) && pg[:db_parameter_group_family].include?('aurora')
+  def self._merge_ids(parameter_group)
+    parameter_group.merge(
+      {
+        _terraform_id: parameter_group[:db_cluster_parameter_group_name],
+        _geo_id: parameter_group[:db_cluster_parameter_group_name],
+        name: parameter_group[:db_cluster_parameter_group_name]
+      }
+    )
   end
 
   def self._fetch_remote_resources(provider)
-    AwsClients.rds(provider)
-              .describe_db_parameter_groups['db_parameter_groups']
-              .map(&:to_h).select { |pg| _is_aurora?(pg) }.map do |pg|
-      pg[:_terraform_id] = pg[:db_parameter_group_name]
-      pg[:_geo_id] = pg[:db_parameter_group_name]
-      pg[:name] = pg[:db_parameter_group_name]
-      pg
-    end
+    AwsClients
+      .rds(provider)
+      .describe_db_cluster_parameter_groups['db_cluster_parameter_groups']
+      .map(&:to_h)
+      .map { |pg| _merge_ids(pg) }
   end
 end

--- a/spec/resources/aws_rds_cluster_parameter_group_spec.rb
+++ b/spec/resources/aws_rds_cluster_parameter_group_spec.rb
@@ -3,30 +3,21 @@ require_relative '../spec_helper'
 describe GeoEngineer::Resources::AwsRdsClusterParameterGroup do
   common_resource_tests(described_class, described_class.type_from_class_name)
 
-  describe "#_is_aurora" do
-    it 'determines if a parameter group is of type aurora' do
-      aurora_pg = { db_parameter_group_family: 'aurora-postgresql9.6' }
-      non_aurora_pg = { db_parameter_group_family: 'mysql5.4' }
-
-      expect(GeoEngineer::Resources::AwsRdsClusterParameterGroup._is_aurora?(aurora_pg)).to eq true
-      expect(GeoEngineer::Resources::AwsRdsClusterParameterGroup._is_aurora?(non_aurora_pg))
-        .to eq false
-    end
-  end
-
   describe "#_fetch_remote_resources" do
     it 'should create list of hashes from returned AWS SDK' do
       rds = AwsClients.rds
       stub = rds.stub_data(
-        :describe_db_parameter_groups,
+        :describe_db_cluster_parameter_groups,
         {
-          db_parameter_groups: [
-            { db_parameter_group_name: 'name1', db_parameter_group_family: 'aurora-postgresql9.6' },
-            { db_parameter_group_name: 'name2', db_parameter_group_family: 'mysql5.4' }
+          db_cluster_parameter_groups: [
+            {
+              db_cluster_parameter_group_name: 'name1',
+              db_parameter_group_family: 'aurora-postgresql9.6'
+            }
           ]
         }
       )
-      rds.stub_responses(:describe_db_parameter_groups, stub)
+      rds.stub_responses(:describe_db_cluster_parameter_groups, stub)
       remote_resources =
         GeoEngineer::Resources::AwsRdsClusterParameterGroup._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 1


### PR DESCRIPTION
This modifies the RDS Cluster parameter group to pull the DB cluster
parameter groups, not the DB parameter groups that happen to be for
aurora DB instances.