### PR TITLE
Add support for most GitHub resources

### DIFF
--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'commander',         '~> 4.4'
   s.add_dependency 'colorize',          '~> 0.7'
   s.add_dependency 'parallel',          '~> 1.10'
+  s.add_dependency 'octokit',           '~> 4.8'
 end

--- a/lib/geoengineer.rb
+++ b/lib/geoengineer.rb
@@ -18,6 +18,7 @@ end
 
 require 'aws-sdk'
 require 'json'
+require 'octokit'
 require 'ostruct'
 require 'uri'
 require 'securerandom'

--- a/lib/geoengineer/environment.rb
+++ b/lib/geoengineer/environment.rb
@@ -18,8 +18,6 @@ class GeoEngineer::Environment
 
   attr_reader :name
 
-  validate -> { validate_required_attributes([:region, :account_id]) }
-
   # Validate resources have unique attributes
   validate -> {
     resources_of_type_grouped_by(&:terraform_name).map do |klass, grouped_resources|
@@ -51,7 +49,7 @@ class GeoEngineer::Environment
   # Validate all resources
   validate -> { all_resources.map(&:errors).flatten }
 
-  before :validation, -> { self.region ||= ENV['AWS_REGION'] }
+  before :validation, -> { self.region ||= ENV['AWS_REGION'] if ENV['AWS_REGION'] }
 
   def initialize(name, &block)
     @name = name

--- a/lib/geoengineer/resources/github_issue_label.rb
+++ b/lib/geoengineer/resources/github_issue_label.rb
@@ -1,0 +1,25 @@
+################################################################################
+# GithubIssueLabel is the +github_issue_label+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/issue_label.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubIssueLabel < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:repository, :name, :color]) }
+
+  after :initialize, -> { _terraform_id -> { "#{repository}:#{name}" } }
+  after :initialize, -> { _geo_id -> { "#{repository}:#{name}" } }
+
+  def self._fetch_remote_resources(provider)
+    repos = GithubClient.organization_repositories(provider.organization)
+
+    Parallel.map(repos, in_threads: Parallel.processor_count * 3) do |repo|
+      labels = GithubClient.labels(repo[:full_name])
+      labels.each do |label|
+        label[:_terraform_id] = "#{repo[:name]}:#{label[:name]}"
+        label[:_geo_id] = collab[:_terraform_id]
+
+        label[:repository] = repo[:name]
+      end
+    end.flatten
+  end
+end

--- a/lib/geoengineer/resources/github_issue_label.rb
+++ b/lib/geoengineer/resources/github_issue_label.rb
@@ -12,7 +12,7 @@ class GeoEngineer::Resources::GithubIssueLabel < GeoEngineer::Resource
   def self._fetch_remote_resources(provider)
     repos = GithubClient.organization_repositories(provider.organization)
 
-    Parallel.map(repos, in_threads: Parallel.processor_count * 3) do |repo|
+    Parallel.map(repos, { in_threads: Parallel.processor_count * 3 }) do |repo|
       labels = GithubClient.labels(repo[:full_name])
       labels.each do |label|
         label[:_terraform_id] = "#{repo[:name]}:#{label[:name]}"

--- a/lib/geoengineer/resources/github_membership.rb
+++ b/lib/geoengineer/resources/github_membership.rb
@@ -1,0 +1,28 @@
+################################################################################
+# GithubMembership is the +github_membership+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/membership.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubMembership < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:username]) }
+
+  after :initialize, -> { _terraform_id -> { "#{fetch_provider.organization}:#{username}" } }
+  after :initialize, -> { _geo_id -> { "#{fetch_provider.organization}:#{username}" } }
+
+  def self._fetch_remote_resources(provider)
+    # GitHub doesn't return the actual role of the member in the API, so we have
+    # to make requests for each role to assign each set the appropriate role
+    roles = %i[admin member]
+    Parallel.map(roles, in_threads: Parallel.processor_count) do |member_role|
+      members = GithubClient.organization_members(provider.organization, { role: member_role })
+
+      members.each do |member|
+        member[:_terraform_id] = "#{provider.organization}:#{member[:login]}"
+        member[:_geo_id] = member[:_terraform_id]
+
+        member[:username] = member[:login]
+        member[:role] = member_role
+      end
+    end.flatten
+  end
+end

--- a/lib/geoengineer/resources/github_membership.rb
+++ b/lib/geoengineer/resources/github_membership.rb
@@ -13,7 +13,7 @@ class GeoEngineer::Resources::GithubMembership < GeoEngineer::Resource
     # GitHub doesn't return the actual role of the member in the API, so we have
     # to make requests for each role to assign each set the appropriate role
     roles = %i[admin member]
-    Parallel.map(roles, in_threads: Parallel.processor_count) do |member_role|
+    Parallel.map(roles, { in_threads: Parallel.processor_count }) do |member_role|
       members = GithubClient.organization_members(provider.organization, { role: member_role })
 
       members.each do |member|

--- a/lib/geoengineer/resources/github_repository.rb
+++ b/lib/geoengineer/resources/github_repository.rb
@@ -1,0 +1,22 @@
+################################################################################
+# GithubRepository is the +github_repository+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/repository.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubRepository < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
+
+  after :initialize, -> { _terraform_id -> { name } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def self._fetch_remote_resources(provider)
+    repos = GithubClient.organization_repositories(provider.organization)
+
+    repos.each do |repo|
+      repo[:_terraform_id] = repo[:name]
+      repo[:_geo_id] = repo[:name]
+      repo[:homepage_url] = repo[:homepage]
+      # TODO: Figure out how to get/set "allow_{rebase,squash,merge} commit
+    end
+  end
+end

--- a/lib/geoengineer/resources/github_repository_collaborator.rb
+++ b/lib/geoengineer/resources/github_repository_collaborator.rb
@@ -1,0 +1,36 @@
+################################################################################
+# GithubRepositoryCollaborator is the +github_repository_collaborator+ Terraform
+# resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/repository_collaborator.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubRepositoryCollaborator < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:repository, :username]) }
+
+  after :initialize, -> { _terraform_id -> { "#{repository}:#{username}" } }
+  after :initialize, -> { _geo_id -> { "#{repository}:#{username}" } }
+
+  def self._fetch_remote_resources(provider)
+    repos = GithubClient.organization_repositories(provider.organization)
+
+    Parallel.map(repos, in_threads: Parallel.processor_count) do |repo|
+      collabs = GithubClient.repository_collaborators(repo[:full_name])
+      collabs.each do |collab|
+        collab[:_terraform_id] = "#{collab[:repository]}:#{collab[:login]}"
+        collab[:_geo_id] = collab[:_terraform_id]
+
+        collab[:username] = collab[:login]
+        collab[:repository] = repo[:name]
+
+        collab[:permission] =
+          if collab[:permissions][:admin]
+            'admin'
+          elsif collab[:permissions][:push]
+            'push'
+          elsif collab[:permissions][:pull]
+            'pull'
+          end
+      end
+    end.flatten
+  end
+end

--- a/lib/geoengineer/resources/github_repository_collaborator.rb
+++ b/lib/geoengineer/resources/github_repository_collaborator.rb
@@ -13,24 +13,27 @@ class GeoEngineer::Resources::GithubRepositoryCollaborator < GeoEngineer::Resour
   def self._fetch_remote_resources(provider)
     repos = GithubClient.organization_repositories(provider.organization)
 
-    Parallel.map(repos, in_threads: Parallel.processor_count) do |repo|
-      collabs = GithubClient.repository_collaborators(repo[:full_name])
-      collabs.each do |collab|
-        collab[:_terraform_id] = "#{collab[:repository]}:#{collab[:login]}"
-        collab[:_geo_id] = collab[:_terraform_id]
-
-        collab[:username] = collab[:login]
-        collab[:repository] = repo[:name]
-
-        collab[:permission] =
-          if collab[:permissions][:admin]
-            'admin'
-          elsif collab[:permissions][:push]
-            'push'
-          elsif collab[:permissions][:pull]
-            'pull'
-          end
-      end
+    Parallel.map(repos, { in_threads: Parallel.processor_count }) do |repo|
+      collaborators_for_repo(repo)
     end.flatten
+  end
+
+  def self.collaborators_for_repo(repo) # rubocop:disable Metrics/AbcSize
+    GithubClient.repository_collaborators(repo[:full_name]).each do |collab|
+      collab[:_terraform_id] = "#{collab[:repository]}:#{collab[:login]}"
+      collab[:_geo_id] = collab[:_terraform_id]
+
+      collab[:username] = collab[:login]
+      collab[:repository] = repo[:name]
+
+      collab[:permission] =
+        if collab[:permissions][:admin]
+          'admin'
+        elsif collab[:permissions][:push]
+          'push'
+        elsif collab[:permissions][:pull]
+          'pull'
+        end
+    end
   end
 end

--- a/lib/geoengineer/resources/github_team.rb
+++ b/lib/geoengineer/resources/github_team.rb
@@ -11,7 +11,7 @@ class GeoEngineer::Resources::GithubTeam < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     GithubClient.organization_teams(provider.organization)
-                 .each do |team|
+                .each do |team|
       team[:_terraform_id] = team[:id].to_s
       team[:_geo_id] = team[:name]
     end

--- a/lib/geoengineer/resources/github_team.rb
+++ b/lib/geoengineer/resources/github_team.rb
@@ -1,0 +1,19 @@
+################################################################################
+# GithubTeam is the +github_team+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/team.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubTeam < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def self._fetch_remote_resources(provider)
+    GithubClient.organization_teams(provider.organization)
+                 .each do |team|
+      team[:_terraform_id] = team[:id].to_s
+      team[:_geo_id] = team[:name]
+    end
+  end
+end

--- a/lib/geoengineer/resources/github_team_membership.rb
+++ b/lib/geoengineer/resources/github_team_membership.rb
@@ -1,0 +1,31 @@
+################################################################################
+# GithubTeamMembership is the +github_team_membership+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/team_membership.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubTeamMembership < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:team_id, :username]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{team_id}:#{username}" } }
+
+  def self._fetch_remote_resources(provider)
+    # There is no way to obtain all these resources in bulk in a single request,
+    # so we iterate over all teams and fetch their individual memberships.
+    # GitHub doesn't return the actual role of the member in the API, so we have
+    # to make calls with different filters to know which role the member has.
+    teams = GithubClient.organization_teams(provider.organization)
+    roles = %i[maintainer member]
+    jobs = teams.map { |team| roles.map { |team_role| [team[:id], team_role] } }.flatten(1)
+
+    Parallel.map(jobs, in_threads: Parallel.processor_count) do |team_id, team_role|
+      GithubClient.team_memberships(team_id, { role: team_role })
+                   .each do |team_membership|
+        team_membership[:_terraform_id] = "#{team_id}:#{team_membership[:login]}"
+        team_membership[:_geo_id] = team_membership[:_terraform_id]
+        team_membership[:username] = team_membership[:login]
+        team_membership[:role] = team_role
+      end
+    end.flatten
+  end
+end

--- a/lib/geoengineer/resources/github_team_repository.rb
+++ b/lib/geoengineer/resources/github_team_repository.rb
@@ -1,0 +1,37 @@
+################################################################################
+# GithubTeamRepository is the +github_team_repository+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/github/r/team_repository.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::GithubTeamRepository < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:team_id, :repository]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{team_id}:#{repository}" } }
+
+  def self._fetch_remote_resources(provider)
+    # There is no way to obtain all these resources in bulk in a single request,
+    # so we iterate over all teams and fetch their individual repo permissions.
+    teams = GithubClient.organization_teams(provider.organization)
+
+    Parallel.map(teams, in_threads: Parallel.processor_count) do |team, team_role|
+      GithubClient.team_repositories(team[:id])
+                   .each do |team_repo|
+        team_repo[:_terraform_id] = "#{team[:id]}:#{team_repo[:name]}"
+        team_repo[:_geo_id] = team_repo[:_terraform_id]
+
+        team_repo[:team_id] = team[:id]
+        team_repo[:repository] = team_repo[:name]
+
+        team_repo[:permission] =
+          if team_repo[:permissions][:admin]
+            'admin'
+          elsif team_repo[:permissions][:push]
+            'push'
+          elsif team_repo[:permissions][:pull]
+            'pull'
+          end
+      end
+    end.flatten
+  end
+end

--- a/lib/geoengineer/utils/github_client.rb
+++ b/lib/geoengineer/utils/github_client.rb
@@ -1,0 +1,31 @@
+########################################################################
+# GithubClient exposes a set of API calls to fetch data from GitHub.
+# The primary reason for centralizing them here is testing and stubbing.
+########################################################################
+class GithubClient
+  Octokit.auto_paginate = true
+
+  def self.organization_members(*args)
+    Octokit.organization_members(*args).map(&:to_h)
+  end
+
+  def self.organization_repositories(*args)
+    Octokit.organization_repositories(*args).map(&:to_h)
+  end
+
+  def self.organization_teams(*args)
+    Octokit.organization_teams(*args).map(&:to_h)
+  end
+
+  def self.repository_collaborators(*args)
+    Octokit.collaborators(*args).map(&:to_h)
+  end
+
+  def self.team_memberships(*args)
+    Octokit.team_members(*args).map(&:to_h)
+  end
+
+  def self.team_repositories(*args)
+    Octokit.team_repositories(*args).map(&:to_h)
+  end
+end


### PR DESCRIPTION
We want to allow GeoEngineer to be used to codify resources in GitHub organizations on the public GitHub as well as GitHub Enterprise.

This PR is lacking tests but works (I've used it to great effect in a project).

The main gotcha is that if you are configuring multiple organizations in a GitHub Enterprise instance, you'll have multiple providers which you'll need to reference via their alias in _every_ resource, e.g.

```ruby
env.provider('github') {
  organization 'org-a'
  self['alias'] = 'org-a'
}

env.provider('github') {
  organization 'org-b'
  self['alias'] = 'org-b'
}

env.resource('github_team', 'org-a-blue-team') {
  name 'blue'
  provider 'github.org-a'
}

env.resource('github_team', 'org-b-red-team') {
  name 'red'
  provider 'github.org-b'
}
```

<!-- The following text is auto-generated from your commit messages -->
### Commit Summary
#### [Add API client support for GitHub](https://github.com/coinbase/geoengineer/commit/77a5d1dd3817bdedecb8d548c90d62698ced7aa4)
We want to allow GeoEngineer to be used to codify resources in GitHub
organizations on the public GitHub as well as GitHub Enterprise.

In order to do that, this commit removes some AWS-specific logic from
the `Environment` class so that it doesn't report validation errors when
we set up a GitHub-specific environment.

---
#### [Add github_team resource](https://github.com/coinbase/geoengineer/commit/ea1eb1b3c052af4c017b5dc6fd304c2f44607c62)
Allows you to create/manage teams within an org.

---
#### [Add github_team_membership resource](https://github.com/coinbase/geoengineer/commit/f10e0ba8cc90a32b3d9afda4ad4eb6055c5c5731)
Allows you to manage memberships of users on teams.

---
#### [Add github_repository resource](https://github.com/coinbase/geoengineer/commit/3f5446a005b911659364465c684af097dad5bcb7)
Allow you to create/manage repositories.

---
#### [Add github_team_repository resource](https://github.com/coinbase/geoengineer/commit/09761fc36004057aa2a43f5fb047c2ea002effef)
Allows adding permissions for specific repositories for a given team.

---
#### [Add github_repository_collaborator resource](https://github.com/coinbase/geoengineer/commit/05c89cd2411b730231dfa34e58a1f286f5b058e4)
Allows you to specify outside collaborators (e.g. people that are not
members of an organization, such as external contractors) for
repositories.

---
#### [Add github_membership resource](https://github.com/coinbase/geoengineer/commit/69765d857d101ae4fba496e1824592d7f4ab3cbb)
Allows you to manage which users are members of an organization.

---
#### [Add github_issue_label resource](https://github.com/coinbase/geoengineer/commit/1d6246c311d13ad6a5f710cd7f7eaed743105e54)
Allows you to create/manage issue labels for a repository.

---
