### PR TITLE
[Update] updated AWS SDK, EIP now supports tags using as _geo_id

### DIFF
--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-byebug", '~> 3.4'
 
   s.add_dependency 'netaddr',           '~> 1.5'
-  s.add_dependency 'aws-sdk',           '~> 2.10'
+  s.add_dependency 'aws-sdk',           '~> 3.0'
   s.add_dependency 'commander',         '~> 4.4'
   s.add_dependency 'colorize',          '~> 0.7'
   s.add_dependency 'parallel',          '~> 1.10'

--- a/lib/geoengineer/resources/aws_cloudfront_distribution.rb
+++ b/lib/geoengineer/resources/aws_cloudfront_distribution.rb
@@ -12,8 +12,8 @@ class GeoEngineer::Resources::AwsCloudfrontDistribution < GeoEngineer::Resource
   def self._fetch_remote_resources(provider)
     AwsClients.cloudfront(provider).list_distributions[:distribution_list][:items].map do |item|
       item.to_h.tap do |i|
-        i[:_terraform_id] = item.id
-        i[:_arn] = item.arn
+        i[:_terraform_id] = item[:id]
+        i[:_arn] = item[:arn]
         i[:_geo_id] = item[:comment]
       end
     end

--- a/lib/geoengineer/resources/aws_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_route_table_association.rb
@@ -9,6 +9,15 @@ class GeoEngineer::Resources::AwsRouteTableAssociation < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{subnet_id}::#{route_table_id}" } }
 
+  def subnet(sn)
+    self.subnet_id = sn._terraform_id || sn.to_ref
+  end
+
+
+  def route_table(rt)
+    self.route_table_id = rt._terraform_id || rt.to_ref
+  end
+
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] = {

--- a/lib/geoengineer/resources/aws_route_table_association.rb
+++ b/lib/geoengineer/resources/aws_route_table_association.rb
@@ -13,7 +13,6 @@ class GeoEngineer::Resources::AwsRouteTableAssociation < GeoEngineer::Resource
     self.subnet_id = sn._terraform_id || sn.to_ref
   end
 
-
   def route_table(rt)
     self.route_table_id = rt._terraform_id || rt.to_ref
   end

--- a/spec/resources/aws_cloudfront_distribution_spec.rb
+++ b/spec/resources/aws_cloudfront_distribution_spec.rb
@@ -4,15 +4,15 @@ describe GeoEngineer::Resources::AwsCloudfrontDistribution do
   let(:aws_client) { AwsClients.cloudfront }
 
   before do
-    response_stub = aws_client.stub_data(
-      :list_distributions,
-      {
-        distribution_list: {
-          items: []
-        }
-      }
-    )
-    aws_client.stub_responses(:list_distributions, response_stub)
+    # Cloudfront stubbing is broken with new api
+    allow(aws_client).to receive(:list_distributions)
+      .and_return({
+                    distribution_list: {
+                      items: [
+
+                      ]
+                    }
+                  })
   end
 
   common_resource_tests(described_class, described_class.type_from_class_name)
@@ -21,21 +21,19 @@ describe GeoEngineer::Resources::AwsCloudfrontDistribution do
     let(:dist_terraform_id) { 'myid' }
 
     before do
-      response_stub = aws_client.stub_data(
-        :list_distributions,
-        {
-          distribution_list: {
-            items: [
-              {
-                id: dist_terraform_id,
-                arn: 'arn:cloudfront:test',
-                comment: 'some-cloudfront-distribution'
-              }
-            ]
-          }
-        }
-      )
-      aws_client.stub_responses(:list_distributions, response_stub)
+      # Cloudfront stubbing is broken with new api
+      allow(aws_client).to receive(:list_distributions)
+        .and_return({
+                      distribution_list: {
+                        items: [
+                          {
+                            id: dist_terraform_id,
+                            arn: 'arn:cloudfront:test',
+                            comment: 'some-cloudfront-distribution'
+                          }
+                        ]
+                      }
+                    })
     end
 
     it 'creates array of hashes from AWS response' do

--- a/spec/resources/aws_eip_spec.rb
+++ b/spec/resources/aws_eip_spec.rb
@@ -10,9 +10,12 @@ describe GeoEngineer::Resources::AwsEip do
       aws_client.stub_responses(
         :describe_addresses, {
           addresses: [
-            { public_ip: '99.0.0.0', allocation_id: "eipalloc-xxxxxxxx" },
+            { public_ip: '99.0.0.0',
+              allocation_id: "eipalloc-xxxxxxxx",
+              tags: [{ key: "Name", value: "eipgeo" }] },
             { public_ip: '99.0.0.1', allocation_id: "eipalloc-xxxxxxxy" }
           ]
+
         }
       )
     end
@@ -23,7 +26,7 @@ describe GeoEngineer::Resources::AwsEip do
 
       test_eip = resources.first
       expect(test_eip[:_terraform_id]).to eql "eipalloc-xxxxxxxx"
-      expect(test_eip[:_geo_id]).to eql "99.0.0.0"
+      expect(test_eip[:_geo_id]).to eql "eipgeo"
     end
   end
 end


### PR DESCRIPTION
AND allowed route table to decide on _geo_id