### PR TITLE
Added default extended attributes for ALB and Target Groups

### DIFF
--- a/lib/geoengineer/resources/aws_lb.rb
+++ b/lib/geoengineer/resources/aws_lb.rb
@@ -12,6 +12,18 @@ class GeoEngineer::Resources::AwsLb < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id       -> { NullObject.maybe(tags)[:Name] } }
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'id' => _terraform_id,
+      'idle_timeout' => '60',
+      'enable_deletion_protection' => 'false',
+      'enable_http2' => 'true',
+      'enable_cross_zone_load_balancing' => 'false'
+    }
+    tfstate
+  end
+
   def short_type
     "lb"
   end

--- a/lib/geoengineer/resources/aws_lb_target_group.rb
+++ b/lib/geoengineer/resources/aws_lb_target_group.rb
@@ -12,6 +12,15 @@ class GeoEngineer::Resources::AwsLbTargetGroup < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id       -> { NullObject.maybe(tags)[:Name] } }
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'id' => _terraform_id,
+      'deregistration_delay' => '300'
+    }
+    tfstate
+  end
+
   def short_type
     "lb_target_group"
   end


### PR DESCRIPTION
This adds the default values for some of the extended attributes on ALBs
and ALB target groups. This prevents erronous plan updates, such as
changing idle_timeout from `""` to `"60"`. That is the default value,
but since it wasn't retrieved by Terraform, it didn't realize it was the
already configured value.