### PR TITLE
Fix kinesis_firehose_delivery_stream Terraform doc url

### DIFF
--- a/lib/geoengineer/resources/aws_kinesis_firehose_delivery_stream.rb
+++ b/lib/geoengineer/resources/aws_kinesis_firehose_delivery_stream.rb
@@ -1,7 +1,7 @@
 ########################################################################
 # AwsKinesisFirehoseDeliveryStream is the +aws_kinesis_firehose_delivery_stream+ terrform resource,
 #
-# {https://www.terraform.io/docs/providers/aws/r/aws_kinesis_firehose_delivery_stream.html
+# {https://www.terraform.io/docs/providers/aws/r/kinesis_firehose_delivery_stream.html
 # Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsKinesisFirehoseDeliveryStream < GeoEngineer::Resource


### PR DESCRIPTION
The provided documentation URL was incorrectly. Fixed it