### PR TITLE
Add aws_cloudwatch_log_group resource

### DIFF
--- a/lib/geoengineer/resources/aws_cloudwatch_log_group.rb
+++ b/lib/geoengineer/resources/aws_cloudwatch_log_group.rb
@@ -1,0 +1,29 @@
+########################################################################
+# AwsCloudwatchLogGroup is the +aws_cloudwatch_log_group+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/cloudwatch_log_group.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsCloudwatchLogGroup < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
+
+  after :initialize, -> { _terraform_id -> { self[:name] } }
+  after :initialize, -> { _geo_id       -> { self[:name] } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients
+      .cloudwatchlogs(provider)
+      .describe_log_groups.log_groups.map(&:to_h).map do |log_group|
+      log_group.merge(
+        {
+          _terraform_id: log_group[:log_group_name],
+          _geo_id: log_group[:log_group_name]
+        }
+      )
+      log_group
+    end
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -61,6 +61,13 @@ class AwsClients
     )
   end
 
+  def self.cloudwatchlogs(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::CloudWatchLogs::Client
+    )
+  end
+
   def self.dynamo(provider = nil)
     self.client_cache(
       provider,

--- a/spec/resources/aws_cloudwatch_log_group_spec.rb
+++ b/spec/resources/aws_cloudwatch_log_group_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsCloudwatchLogGroup do
+  let(:aws_client) { AwsClients.cloudwatchlogs }
+
+  before { aws_client.setup_stubbing }
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_log_groups,
+        {
+          log_groups: [
+            { log_group_name: 'name1',
+              creation_time: 1,
+              metric_filter_count: 0,
+              arn: "no",
+              stored_bytes: -1 }
+          ]
+        }
+      )
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsCloudwatchLogGroup._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
I need this so that I can setup log groups for lambdas when deploying
them for the first time.