### PR TITLE
Fix fetching of more than 20 ALB target groups

### DIFF
--- a/lib/geoengineer/resources/aws_lb_target_group.rb
+++ b/lib/geoengineer/resources/aws_lb_target_group.rb
@@ -12,6 +12,8 @@ class GeoEngineer::Resources::AwsLbTargetGroup < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id       -> { NullObject.maybe(tags)[:Name] } }
 
+  MAX_RESOURCES_PER_REQUEST = 20
+
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] = {
@@ -38,14 +40,35 @@ class GeoEngineer::Resources::AwsLbTargetGroup < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    target_groups = AwsClients.alb(provider).describe_target_groups.target_groups
+    client = AwsClients.alb(provider)
+
+    target_groups = _fetch_all_target_groups(true, [], client, nil)
     return [] if target_groups.empty?
 
-    tags = AwsClients.alb(provider)
-                     .describe_tags({ resource_arns: target_groups.map(&:target_group_arn) })
-                     .tag_descriptions
-                     .map(&:to_h)
+    tags = _fetch_all_target_groups_tags(target_groups, client)
 
     _merge_attributes(target_groups.map(&:to_h), tags)
+  end
+
+  def self._fetch_all_target_groups(continue, target_groups, client, marker)
+    return target_groups unless continue
+    target_group_resp = client.describe_target_groups({ marker: marker,
+                                                        page_size: MAX_RESOURCES_PER_REQUEST })
+    _fetch_all_target_groups(target_group_resp.next_page?,
+                             target_groups + target_group_resp['target_groups'],
+                             client,
+                             target_group_resp.next_marker)
+  end
+
+  def self._fetch_all_target_groups_tags(target_groups, client)
+    arn_chunks = target_groups.each_slice(MAX_RESOURCES_PER_REQUEST).map do |chunk|
+      chunk.map(&:target_group_arn)
+    end
+
+    Parallel.map(arn_chunks, { in_threads: Parallel.processor_count }) do |target_group_arns|
+      client.describe_tags({ resource_arns: target_group_arns })
+            .tag_descriptions
+            .map(&:to_h)
+    end.flatten
   end
 end


### PR DESCRIPTION
When generating a plan where there were a lot of load balancer target groups defined, the AWS SDK would complain that we can only fetch 20 resources at a given time.

This required two fixes: one where we page through the result set when fetching all target groups, and another where we fetch tags specifying the explicit ARNs for those target groups. In both cases, we only fetch 20 resources at a time.

We opted to fetch the tags in parallel because we know the ARNs ahead of time, whereas when fetching the initial list of load balancers we have to perform this in serial.
