### PR TITLE
[FIX] Support more than 20 ALB's per Account

### DIFF
--- a/spec/resources/aws_lb_spec.rb
+++ b/spec/resources/aws_lb_spec.rb
@@ -36,5 +36,21 @@ describe GeoEngineer::Resources::AwsLb do
       remote_resources = GeoEngineer::Resources::AwsLb._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 0
     end
+
+    it "should work if more than 20 ALB's are returned" do
+      albs = (1..30).map { |n| { load_balancer_arn: "foo/alb-#{n}" } }
+      tags = albs.map do |alb|
+        {
+          resource_arn: alb[:load_balancer_arn],
+          tags: [{ key: "Name", value: alb[:load_balancer_arn] }]
+        }
+      end
+
+      alb_client.stub_responses(:describe_load_balancers, { load_balancers: albs })
+      alb_client.stub_responses(:describe_tags, { tag_descriptions: tags })
+
+      remote_resources = GeoEngineer::Resources::AwsLb._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 30
+    end
   end
 end


### PR DESCRIPTION
AWS limits the number of ALB's that can be passed to a describe tags
call to 20. This accounts for that.
