### PR TITLE
aws_iam_saml_provider: dont support tags + support terraform / geo id

### DIFF
--- a/lib/geoengineer/resources/aws/iam/aws_iam_saml_provider.rb
+++ b/lib/geoengineer/resources/aws/iam/aws_iam_saml_provider.rb
@@ -6,20 +6,23 @@
 class GeoEngineer::Resources::AwsIamSamlProvider < GeoEngineer::Resource
   validate -> { validate_required_attributes([:name, :saml_metadata_document]) }
 
-  after :initialize, -> { _terraform_id -> { name } }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name.to_s } }
 
   def support_tags?
     false
   end
 
   def self._fetch_remote_resources(provider)
+    idp_reg = %r{^arn:aws:iam::[0-9]{12}:saml-provider/(.+)$}
     AwsClients.iam(provider)
               .list_saml_providers
               .saml_provider_list
               .map do |idp|
+                name = idp.arn[idp_reg, 1]
                 {
                   _terraform_id: idp.arn,
-                  _geo_id: idp.arn
+                  _geo_id: name
                 }
               end
   end

--- a/lib/geoengineer/resources/aws/iam/aws_iam_saml_provider.rb
+++ b/lib/geoengineer/resources/aws/iam/aws_iam_saml_provider.rb
@@ -8,6 +8,10 @@ class GeoEngineer::Resources::AwsIamSamlProvider < GeoEngineer::Resource
 
   after :initialize, -> { _terraform_id -> { name } }
 
+  def support_tags?
+    false
+  end
+
   def self._fetch_remote_resources(provider)
     AwsClients.iam(provider)
               .list_saml_providers

--- a/spec/resources/aws_iam_saml_provider_spec.rb
+++ b/spec/resources/aws_iam_saml_provider_spec.rb
@@ -10,7 +10,9 @@ describe(GeoEngineer::Resources::AwsIamSamlProvider) do
     before do
       list_resp = double()
       saml_resp = double()
-      allow(saml_resp).to receive(:arn).and_return("arn::some:stuf:here:lol")
+      allow(saml_resp).to receive(:arn).and_return(
+        "arn:aws:iam::123456789012:saml-provider/ADFSProvider"
+      )
       allow(list_resp).to receive(:saml_provider_list).and_return([saml_resp])
       aws_client.stub_responses(:list_saml_providers, list_resp)
     end


### PR DESCRIPTION
aws_iam_saml_provider terraform_id must be aws arn

As specified in terraform's
[aws_iam_saml_provider](https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_iam_saml_provider.go#L62)
