### PR TITLE
Add support for aws_vpc_ipv4_cidr_block_association resources

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_vpc_ipv4_cidr_block_association.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_vpc_ipv4_cidr_block_association.rb
@@ -1,0 +1,117 @@
+########################################################################
+# AwsVpcIpv4CidrBlockAssociation is the +aws_vpc_ipv4_cidr_block_association+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/vpc_ipv4_cidr_block_association.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:vpc_id, :cidr_block]) }
+  validate -> { validate_cidr_block(self.cidr_block) if self.cidr_block }
+  validate -> {
+    if self.vpc_id.is_a?(GeoEngineer::Resource)
+      primary_cidr = self.vpc_id.cidr_block
+      validate_cidr_restrictions(primary_cidr, self.cidr_block) if self.cidr_block && primary_cidr
+    end
+  }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{_vpc_id}::#{cidr_block}" } }
+
+  def _vpc_id
+    self.vpc_id && self.vpc_id.is_a?(GeoEngineer::Resource) ? self.vpc_id._terraform_id : self.vpc_id
+  end
+
+  def cidr(range)
+    NetAddr::CIDR.create(range)
+  end
+
+  def range_size(errors, additional_cidr)
+    msg = "The allowed block size is between a /28 netmask and /16 netmask."
+    errors << err_msg(msg) if additional_cidr.bits < 16 || additional_cidr.bits > 28
+  end
+
+  def single_restricted_range(errors, primary_cidr, additional_cidr)
+    restricted_ranges = [cidr("10.0.0.0/8"),
+                         cidr("172.16.0.0/12"),
+                         cidr("192.168.0.0/16"),
+                         cidr("198.19.0.0/16")]
+    remaining_restricted_ranges = restricted_ranges.reject { |r| r.contains?(primary_cidr) }
+
+    remaining_restricted_ranges.each do |r|
+      if r.contains?(additional_cidr)
+        errors << err_msg("Primary VPC range [#{primary_cidr}] Cannot add additional CIDR blocks from the restricted "\
+          "ranges [ #{remaining_restricted_ranges.join(', ')} ]")
+      end
+    end
+  end
+
+  def no_overlap(errors, primary_cidr, additional_cidr)
+    msg = "The additional CIDR cannot overlap the primary VPC range"
+    errors << err_msg(msg) if primary_cidr.contains?(additional_cidr)
+  end
+
+  def special_ranges(errors, primary_cidr, additional_cidr)
+    rule1 = cidr("10.0.0.0/15").contains?(primary_cidr) && cidr("10.0.0.0/16").contains?(additional_cidr)
+    msg1 = "primary CIDR in 10.0.0.0/15. cannot add a CIDR block from the 10.0.0.0/16 range."
+    errors << err_msg(msg1) if rule1
+
+    rule2 = cidr("172.16.0.0/12").contains?(primary_cidr) && cidr("172.31.0.0/16").contains?(additional_cidr)
+    msg2 = "primary CIDR in 172.16.0.0/12. cannot add a CIDR block from the 172.31.0.0/16 range"
+    errors << err_msg(msg2) if rule2
+  end
+
+  def err_msg(msg)
+    link = "https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#add-cidr-block-restrictions"
+    "#{for_resource} : #{msg} See #{link} for more info."
+  end
+
+  def validate_cidr_restrictions(primary, cidr_block)
+    errors = []
+    begin
+      primary_cidr = cidr(primary)
+    rescue NetAddr::ValidationError
+      return errors
+    end
+    additional_cidr = cidr(cidr_block)
+
+    range_size(errors, additional_cidr)
+
+    no_overlap(errors, primary_cidr, additional_cidr)
+
+    return errors if cidr("100.64.0.0/10").contains?(additional_cidr)
+
+    single_restricted_range(errors, primary_cidr, additional_cidr)
+
+    special_ranges(errors, primary_cidr, additional_cidr)
+
+    errors
+  end
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'vpc_id' => vpc_id,
+      'cidr_block' => cidr_block
+    }
+    tfstate
+  end
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.ec2(provider)
+              .describe_vpcs['vpcs']
+              .map(&:to_h)
+              .flat_map do |vpc|
+      vpc[:cidr_block_association_set].map do |cidr_assoc|
+        {
+          vpc_id: vpc[:vpc_id],
+          cidr_block: cidr_assoc[:cidr_block],
+          _geo_id: "#{vpc[:vpc_id]}::#{cidr_assoc[:cidr_block]}",
+          _terraform_id: cidr_assoc[:association_id]
+        }
+      end
+    end
+  end
+end

--- a/spec/resources/aws_vpc_ipv4_cidr_block_association_spec.rb
+++ b/spec/resources/aws_vpc_ipv4_cidr_block_association_spec.rb
@@ -1,0 +1,86 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation) do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#validate_cidr_restrictions" do
+    [
+      ["10.100.0.0/24", "10.150.0.0/13", "should not allow a cidr range bigger than /16"],
+      ["10.100.0.0/24", "10.150.0.0/29", "should not allow a cidr range smaller than /28"],
+      ["10.100.0.0/24", "10.100.0.0/25", "should not allow a cidr to overlap the primary vpc range"],
+      ["10.0.0.0/20", "10.0.0.0/17", "should not allow a cidr in 10.0.0.0/16 if the primary vpc range "\
+        "is in 10.0.0.0/15"],
+      ["172.16.0.0/14", "172.31.0.0/18", "should not allow a cidr in 172.31.0.0/16 if the primary vpc "\
+        "range is in 172.16.0.0/12"],
+      ["10.0.0.0/20", "172.31.0.0/18", "should not allow a cidr from a different restricted ranges than "\
+        "the range the VPC is in"],
+      ["172.17.0.0/24", "192.168.0.0/24", "should not allow a cidr from a different restricted range ranges "\
+        "than the range the VPC is in"],
+      ["192.168.0.0/16", "172.31.0.0/18", "should not allow a cidr from a different restricted range than "\
+        "the range the VPC is in"],
+      ["198.19.0.0/16", "172.31.0.0/18", "should not allow a cidr from a different restricted range than "\
+        "the range the VPC is in"]
+    ].each do |test|
+      it test[2] do
+        res = GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation.allocate()
+        errs = res.validate_cidr_restrictions(test[0], test[1])
+        expect(errs.length).to eq(1)
+      end
+    end
+
+    it 'should allow cidr blocks in the 100.64.0.0/10 range' do
+      res = GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation.allocate()
+      errs = res.validate_cidr_restrictions("10.100.0.0/24", "100.96.0.0/16")
+      expect(errs.length).to eq(0)
+    end
+  end
+
+  describe "#_fetch_remote_resources" do
+    let(:ec2) { AwsClients.ec2 }
+    before do
+      stub = ec2.stub_data(
+        :describe_vpcs,
+        {
+          vpcs: [
+            {
+              vpc_id: 'name1',
+              cidr_block: "10.10.0.0/24",
+              tags: [{ key: 'Name', value: 'one' }],
+              cidr_block_association_set: [
+                {
+                  association_id: 'cidr_assoc_1',
+                  cidr_block: '10.100.240.0/22'
+                },
+                {
+                  association_id: 'cidr_assoc_2',
+                  cidr_block: '100.96.0.0/16'
+                }
+              ]
+            },
+            {
+              vpc_id: 'name2',
+              cidr_block: "10.10.1.0/24",
+              tags: [{ key: 'Name', value: 'two' }],
+              cidr_block_association_set: [
+                {
+                  association_id: 'cidr_assoc_3',
+                  cidr_block: '10.100.184.0/22'
+                }
+              ]
+            }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_vpcs, stub)
+    end
+
+    after do
+      ec2.stub_responses(:describe_vpcs, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
https://www.terraform.io/docs/providers/aws/r/vpc_ipv4_cidr_block_association.html

There are quite a few rules about what additional ranges on a vpc can look [like](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Subnets.html#add-cidr-block-restrictions).

I didn't look at every resource, but I couldn't find any example of validating based on the attribute of an associated resource. In this case we need the primary cidr of the vpc. It seemed like it was worth the effort because most of the time I would expect that vpc and aws_vpc_ipv4_cidr_block_association resources get codified together. If the vpc_id attribute of the aws_vpc_ipv4_cidr_block_association resource isn't a ref to another `GeoEngineer::Resource` then the complicated validation is just skipped. 

This may be overly ambitious and if so I could just take out the complicated validation and go with the basic cidr parsing that seems pretty well represented in a lot of existing resources. 

Also any ruby tips are welcome -- it's been a while 🌈 