### PR TITLE
Removes invalid fields from aws_rds_cluster_instance

### DIFF
--- a/lib/geoengineer/resources/aws/rds/aws_rds_cluster_instance.rb
+++ b/lib/geoengineer/resources/aws/rds/aws_rds_cluster_instance.rb
@@ -4,7 +4,6 @@
 # {https://www.terraform.io/docs/providers/aws/r/db_instance.html Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsRdsClusterInstance < GeoEngineer::Resource
-  validate -> { validate_required_attributes([:password, :username, :name]) if new? }
   validate -> { validate_required_attributes([:db_subnet_group_name]) unless publicly_accessible }
   validate -> { validate_required_attributes([:cluster_identifier, :instance_class, :engine]) }
 


### PR DESCRIPTION
This removes the validation to require `name`, `username`, and `password` fields
from `aws_rds_cluster_instance`. These are set on `aws_rds_cluster` rather than
on the instance itself.