### PR TITLE
Fix RuboCop warnings

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -40,6 +40,8 @@ Metrics/BlockLength:
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
   Max: 20
+  Exclude:
+    - 'lib/geoengineer/cli/terraform_commands.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 AwsClients.stub!
 
 # Common Resource Class Tests
-# rubocop:disable Metrics/AbcSize
 def init_test(clazz_name)
   it "should initialize and error" do
     env = GeoEngineer::Environment.new("name")


### PR DESCRIPTION
These are breaking the build and in this particular case aren't useful.
