### PR TITLE
[Refactor] lb geo_id to name, removing tags fetches

### DIFF
--- a/lib/geoengineer/resources/aws/lb/aws_lb.rb
+++ b/lib/geoengineer/resources/aws/lb/aws_lb.rb
@@ -7,10 +7,9 @@ class GeoEngineer::Resources::AwsLb < GeoEngineer::Resource
   validate -> { validate_required_attributes([:subnets]) }
   validate -> { validate_subresource_required_attributes(:access_logs, [:bucket]) }
   validate -> { validate_subresource_required_attributes(:subnet_mapping, [:subnet_id]) }
-  validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id       -> { NullObject.maybe(tags)[:Name] } }
+  after :initialize, -> { _geo_id       -> { name } }
 
   # The ALB client only allows fetching the tags from 20 ALBs at once
   MAXIMUM_FETCHABLE_ALBS = 20
@@ -31,35 +30,11 @@ class GeoEngineer::Resources::AwsLb < GeoEngineer::Resource
     "lb"
   end
 
-  def self._merge_attributes(albs, tags)
-    albs.map do |alb|
-      alb_tags = tags.find { |desc| desc[:resource_arn] == alb[:load_balancer_arn] }
-      alb.merge(
-        {
-          _terraform_id: alb[:load_balancer_arn],
-          _geo_id: alb_tags[:tags]&.find { |tag| tag[:key] == "Name" }.dig(:value)
-        }
-      )
-    end
-  end
-
-  def self._fetch_alb_tags(client, albs)
-    arns = albs.map { |alb| alb[:load_balancer_arn] }
-    tags = client.describe_tags({ resource_arns: arns })
-    tags.tag_descriptions.map(&:to_h)
-  end
-
   def self._fetch_remote_resources(provider)
     client = AwsClients.alb(provider)
-    albs = client.describe_load_balancers['load_balancers'].map(&:to_h)
-    return [] if albs.empty?
-
-    tags = []
-
-    albs.each_slice(MAXIMUM_FETCHABLE_ALBS) do |alb_slice|
-      tags += _fetch_alb_tags(client, alb_slice) || []
+    client.describe_load_balancers['load_balancers'].map(&:to_h).map do |lb|
+      lb[:_terraform_id] = lb[:load_balancer_arn]
+      lb[:_geo_id] = lb[:load_balancer_name]
     end
-
-    _merge_attributes(albs, tags)
   end
 end

--- a/spec/resources/aws_lb_spec.rb
+++ b/spec/resources/aws_lb_spec.rb
@@ -44,8 +44,7 @@ describe GeoEngineer::Resources::AwsLb do
     it 'will work with > 20 ALBs' do
       arns = (1..21).map { |i| { load_balancer_arn: "foo/repo-#{i}" } }
       alb_client.stub_responses(:describe_load_balancers, { load_balancers: arns })
-      expect(GeoEngineer::Resources::AwsLb).to receive(:_fetch_alb_tags)
-        .twice.and_call_original
+
       remote_resources = GeoEngineer::Resources::AwsLb._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 21
     end


### PR DESCRIPTION
The load balancer resource must have a unique name, so we can use that as a geo id instead of tags. This saves a few API calls and also simplifies the code.