### PR TITLE
Add aws_dx_connection resource

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_dx_connection.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_dx_connection.rb
@@ -1,0 +1,24 @@
+########################################################################
+# AwsDxConnection is the +aws_dx_connection+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/dx_connection.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsDxConnection < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :bandwidth, :location]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.directconnect(provider)
+              .describe_connections['connections'].map(&:to_h).map do |connection|
+      connection.merge(
+        {
+          _terraform_id: connection[:connection_id],
+          _geo_id: connection[:connection_name]
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -68,6 +68,13 @@ class AwsClients
     )
   end
 
+  def self.directconnect(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::DirectConnect::Client
+    )
+  end
+
   def self.dynamo(provider = nil)
     self.client_cache(
       provider,

--- a/spec/resources/aws_dx_connection_spec.rb
+++ b/spec/resources/aws_dx_connection_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsDxConnection) do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      directconnect = AwsClients.directconnect
+      stub = directconnect.stub_data(
+        :describe_connections,
+        {
+          connections: [
+            { connection_id: 'name1', bandwidth: "10Gbps", location: "EqDC2" },
+            { connection_id: 'name2', bandwidth: "10Gbps", location: "EqDC2" }
+          ]
+        }
+      )
+      directconnect.stub_responses(:describe_connections, stub)
+      remote_resources = GeoEngineer::Resources::AwsDxConnection._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This adds the `aws_dx_connection` resource, which is used to set up Direct
Connect. Overall it is a simple object, but will have following resources to add
once my existing DC request is activated within AWS.