### PR TITLE
[Fix] better stubbing for `geo test` command

### DIFF
--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -11,6 +11,7 @@ class GeoCLI
 end
 
 require_relative './status_command'
+require_relative './test_cmd_stubs'
 require_relative './terraform_commands'
 
 def environment(name, &block)

--- a/lib/geoengineer/cli/terraform_commands.rb
+++ b/lib/geoengineer/cli/terraform_commands.rb
@@ -87,7 +87,7 @@ module GeoCLI::TerraformCommands
       action = lambda do |args, options|
         create_terraform_files(false)
       end
-      c.action ->(args, options) { AwsClients.stub! && init_action(:plan, &action).call(args, options) }
+      c.action ->(args, options) { GeoCLI::TestCmdStubs.stub! && init_action(:plan, &action).call(args, options) }
     end
   end
 

--- a/lib/geoengineer/cli/test_cmd_stubs.rb
+++ b/lib/geoengineer/cli/test_cmd_stubs.rb
@@ -1,0 +1,15 @@
+module GeoCLI::TestCmdStubs
+  def self.stub!
+    puts "Stubbing Commands"
+    AwsClients.stub!
+
+    # This method errors for some reason
+    AwsClients.kinesis.stub_responses(
+      :list_streams,
+      {
+        stream_names: [],
+        has_more_streams: false
+      }
+    )
+  end
+end

--- a/lib/geoengineer/cli/test_cmd_stubs.rb
+++ b/lib/geoengineer/cli/test_cmd_stubs.rb
@@ -1,3 +1,4 @@
+# Stubs for `geo test` command
 module GeoCLI::TestCmdStubs
   def self.stub!
     puts "Stubbing Commands"


### PR DESCRIPTION
When the `geo test` command is run this allows more stubbing as some AWS stubs do not properly work with no expected return.