### PR TITLE
Add support for aws_rds_cluster_endpoint

### DIFF
--- a/lib/geoengineer/resources/aws/rds/aws_rds_cluster_endpoint.rb
+++ b/lib/geoengineer/resources/aws/rds/aws_rds_cluster_endpoint.rb
@@ -1,0 +1,43 @@
+########################################################################
+# AwsRdsClusterEndpoint is the +aws_rds_cluster_endpoint+ terraform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/rds_cluster_endpoint.html}
+########################################################################
+class GeoEngineer::Resources::AwsRdsClusterEndpoint < GeoEngineer::Resource
+  validate -> {
+    validate_required_attributes(
+      [
+        :cluster_identifier,
+        :cluster_endpoint_identifier,
+        :custom_endpoint_type
+      ]
+    )
+  }
+
+  after :initialize, -> { _terraform_id -> { cluster_identifier } }
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'cluster_identifier' => _terraform_id
+    }
+    tfstate
+  end
+
+  def short_type
+    'rds_cluster_endpoint'
+  end
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.rds(provider).describe_db_cluster_endpoints['db_cluster_endpoints'].map(&:to_h).map do |endpoint|
+      endpoint[:_terraform_id] = endpoint[:db_cluster_identifier]
+      endpoint[:_geo_id] = endpoint[:db_cluster_identifier]
+      endpoint[:cluster_identifier] = endpoint[:db_cluster_identifier]
+      endpoint
+    end
+  end
+end

--- a/spec/resources/aws_rds_cluster_endpoint_spec.rb
+++ b/spec/resources/aws_rds_cluster_endpoint_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsRdsClusterEndpoint do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      rds = AwsClients.rds
+      stub = rds.stub_data(
+        :describe_db_cluster_endpoints,
+        {
+          db_cluster_endpoints: [
+            { db_cluster_identifier: 'name1' },
+            { db_cluster_identifier: 'name2' }
+          ]
+        }
+      )
+      rds.stub_responses(:describe_db_cluster_endpoints, stub)
+      remote_resources = GeoEngineer::Resources::AwsRdsClusterEndpoint._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
Implement the AwsRdsClusterEndpoint class to support creating custom
endpoints with AWS Aurora.

Used locally in staging environment for testing it works as expected.