### PR TITLE
Rename type To _type On GeoEngineer::Resource

### DIFF
--- a/lib/geoengineer/environment.rb
+++ b/lib/geoengineer/environment.rb
@@ -162,8 +162,8 @@ class GeoEngineer::Environment
 
   def json_resources
     all_resources.each_with_object({}) do |r, c|
-      c[r.type] ||= {}
-      c[r.type][r.id] = r.to_terraform_json
+      c[r._type] ||= {}
+      c[r._type][r.id] = r.to_terraform_json
       c
     end
   end
@@ -172,7 +172,7 @@ class GeoEngineer::Environment
     reses = all_resources.select(&:_terraform_id) # _terraform_id must not be nil
 
     reses = Parallel.map(reses, { in_threads: Parallel.processor_count }) do |r|
-      { "#{r.type}.#{r.id}" => r.to_terraform_state() }
+      { "#{r._type}.#{r.id}" => r.to_terraform_state() }
     end.reduce({}, :merge)
 
     {

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_deployment.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_deployment.rb
@@ -15,7 +15,7 @@ class GeoEngineer::Resources::AwsApiGatewayDeployment < GeoEngineer::Resource
   after :initialize, -> {
     if self._rest_api
       self.rest_api_id = _rest_api.to_ref
-      _rest_api.api_resources[self.type][self.id] = self
+      _rest_api.api_resources[self._type][self.id] = self
       depends_on [_rest_api].map(&:terraform_name)
     end
   }

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_integration.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_integration.rb
@@ -18,7 +18,7 @@ class GeoEngineer::Resources::AwsApiGatewayIntegration < GeoEngineer::Resource
   }
 
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
-  after :initialize, -> { _rest_api.api_resources[self.type][self.id] = self }
+  after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
   after :initialize, -> { self.resource_id = _resource.to_ref }
   after :initialize, -> { depends_on [_rest_api, _resource].map(&:terraform_name) }

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_integration_response.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_integration_response.rb
@@ -18,7 +18,7 @@ class GeoEngineer::Resources::AwsApiGatewayIntegrationResponse < GeoEngineer::Re
   }
 
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
-  after :initialize, -> { _rest_api.api_resources[self.type][self.id] = self }
+  after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
   after :initialize, -> { self.resource_id = _resource.to_ref }
   after :initialize, -> { depends_on [_rest_api, _resource].map(&:terraform_name) }

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
@@ -19,7 +19,7 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
 
   # Must pass the rest_api as _rest_api resource for additional information
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
-  after :initialize, -> { _rest_api.api_resources[self.type][self.id] = self }
+  after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
   after :initialize, -> { self.resource_id = _resource.to_ref }
   after :initialize, -> { depends_on [_rest_api, _resource].map(&:terraform_name) }

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method_response.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method_response.rb
@@ -19,7 +19,7 @@ class GeoEngineer::Resources::AwsApiGatewayMethodResponse < GeoEngineer::Resourc
 
   # Must pass the rest_api as _rest_api resource for additional information
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
-  after :initialize, -> { _rest_api.api_resources[self.type][self.id] = self }
+  after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
   after :initialize, -> { self.resource_id = _resource.to_ref }
   after :initialize, -> { depends_on [_rest_api, _resource].map(&:terraform_name) }

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_resource.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_resource.rb
@@ -12,7 +12,7 @@ class GeoEngineer::Resources::AwsApiGatewayResource < GeoEngineer::Resource
   validate -> { validate_required_attributes([:rest_api_id, :parent_id, :path_part]) }
 
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
-  after :initialize, -> { _rest_api.api_resources[self.type][self.id] = self }
+  after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
   # Users get the root resource ('/') as parent by default, but can optionally set
   # it to another resource. This allows for hierarchically organizing API gateway

--- a/lib/geoengineer/sub_resource.rb
+++ b/lib/geoengineer/sub_resource.rb
@@ -9,11 +9,11 @@ class GeoEngineer::SubResource
   include HasAttributes
   include HasSubResources
 
-  attr_reader :type
+  attr_reader :_type
 
   def initialize(resource, type, &block)
     @resource = resource
-    @type = type.to_s
+    @_type = type.to_s
     instance_exec(self, &block) if block_given?
   end
 
@@ -23,7 +23,7 @@ class GeoEngineer::SubResource
 
   ## Terraform methods
   def to_terraform
-    sb = ["  #{@type} { "]
+    sb = ["  #{@_type} { "]
 
     sb.concat terraform_attributes.map { |k, v|
       "  #{k.to_s.inspect} = #{v.inspect}"
@@ -40,6 +40,6 @@ class GeoEngineer::SubResource
       json[k] ||= []
       json[k] << v
     end
-    [@type, json]
+    [@_type, json]
   end
 end

--- a/lib/geoengineer/utils/has_resources.rb
+++ b/lib/geoengineer/utils/has_resources.rb
@@ -28,7 +28,7 @@ module HasResources
   end
 
   def find_resource(type, id)
-    all_resources.select { |r| r.type == type && r.id == id }.first
+    all_resources.select { |r| r._type == type && r.id == id }.first
   end
 
   def find_resource_by_ref(ref)
@@ -50,7 +50,7 @@ module HasResources
 
   # Returns: { type1: { value1: [ ] }, type2: { value2: [ ] } }
   def resources_of_type_grouped_by(&block)
-    grouped = resources_grouped_by(all_resources, &:type)
+    grouped = resources_grouped_by(all_resources, &:_type)
 
     grouped_arr = grouped.map do |type, grouped_resources|
       [type, resources_grouped_by(grouped_resources, &block)]
@@ -60,7 +60,7 @@ module HasResources
   end
 
   def resources_of_type(type)
-    all_resources.select { |r| r.type == type }
+    all_resources.select { |r| r._type == type }
   end
 
   # Factory to create resource and attach

--- a/lib/geoengineer/utils/has_sub_resources.rb
+++ b/lib/geoengineer/utils/has_sub_resources.rb
@@ -16,7 +16,7 @@ module HasSubResources
       name = name[4..-1]
       all = true
     end
-    srl = subresources.select { |s| s.type == name.to_s }
+    srl = subresources.select { |s| s._type == name.to_s }
 
     if srl.empty?
       return [] if all
@@ -38,6 +38,6 @@ module HasSubResources
   end
 
   def delete_all_subresources(type)
-    @_subresources = subresources.select { |s| s.type != type.to_s }
+    @_subresources = subresources.select { |s| s._type != type.to_s }
   end
 end


### PR DESCRIPTION
Rename the `type` field to `_type` to avoid conflicts for resources that also
require an attribute named `type`.