### PR TITLE
Add _policy_file Shorthand For API Gateway Rest API

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_rest_api.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_rest_api.rb
@@ -58,6 +58,10 @@ class GeoEngineer::Resources::AwsApiGatewayRestApi < GeoEngineer::Resource
     NullObject.maybe(remote_resource).root_resource_id
   end
 
+  def _policy_file(path)
+    policy _json_file(:policy, path)
+  end
+
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] = {


### PR DESCRIPTION
Add the `_policy_file` shorthand for `aws_api_gateway_rest_api` resources to
make defining the resource policy simpler. Currently you have to write
something like the following:

```
policy _json_file(:policy, '<PATH>')
```

After this change you would simply write

```
_policy_file '<PATH>'
```