### PR TITLE
Update aws_lambda_event_source_mapping.rb

### DIFF
--- a/lib/geoengineer/resources/aws/lambda/aws_lambda_event_source_mapping.rb
+++ b/lib/geoengineer/resources/aws/lambda/aws_lambda_event_source_mapping.rb
@@ -5,7 +5,7 @@
 ########################################################################
 class GeoEngineer::Resources::AwsLambdaEventSourceMapping < GeoEngineer::Resource
   validate -> {
-    validate_required_attributes([:event_source_arn, :function_name, :starting_position])
+    validate_required_attributes([:event_source_arn, :function_name])
   }
   validate -> {
     if self.starting_position && !%w[TRIM_HORIZON LATEST].include?(self.starting_position)


### PR DESCRIPTION
Starting position is only required for Kinesis event mappings, and is not allowed for SQS event mappings.