### PR TITLE
Fix Stage Name Bug In AwsApiGatewayMethodSettings

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method_settings.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method_settings.rb
@@ -23,7 +23,7 @@ class GeoEngineer::Resources::AwsApiGatewayMethodSettings < GeoEngineer::Resourc
   after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
   after :initialize, -> {
-    self.stage_name = _stage.to_ref
+    self.stage_name = _stage.stage_name if _stage
     if _resource && _method
       self.method_path = "#{_resource.path_part}/#{_method.http_method}"
     end


### PR DESCRIPTION
Previously we were using the stages ID when what is actually requested is the
name of the stage. This change fixes this bug and also allows for users to
optionally specify the stage name themselves.