### PR TITLE
Add support for aws_organizations_* objects

### DIFF
--- a/lib/geoengineer/resources/aws/organizations/aws_organizations_account.rb
+++ b/lib/geoengineer/resources/aws/organizations/aws_organizations_account.rb
@@ -1,0 +1,35 @@
+########################################################################
+# AwsOrganizationsAccount is the +aws_organizations_account+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/organizations_account.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsOrganizationsAccount < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :email]) }
+
+  after :initialize, -> {
+    _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id }
+  }
+  after :initialize, -> {
+    _geo_id -> { name }
+
+    # Have terraform ignore changes to role_name because this value is only used
+    # on creation and not persisted.
+    self.lifecycle {} unless self.lifecycle
+    self.lifecycle.ignore_changes ||= []
+    self.lifecycle.ignore_changes |= ["role_name"]
+  }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.organizations(provider).list_accounts.accounts.map(&:to_h).map do |ac|
+      {
+        _terraform_id: ac[:id],
+        _geo_id: ac[:name],
+        name: ac[:name]
+      }
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/organizations/aws_organizations_organization.rb
+++ b/lib/geoengineer/resources/aws/organizations/aws_organizations_organization.rb
@@ -1,0 +1,30 @@
+########################################################################
+# AwsOrganizationsOrganization is the +aws_organizations_organization+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/organizations_organization.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsOrganizationsOrganization < GeoEngineer::Resource
+  after :initialize, -> {
+    _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id }
+  }
+
+  # A fixed string is used here because an account can only have one
+  # organization, so if multiple get defined, we want geo to error.
+  after :initialize, -> { _geo_id -> { "aws_organization" } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    org = AwsClients.organizations(provider).describe_organization().organization.to_h
+
+    [{
+      _terraform_id: org[:id],
+      _geo_id: "aws_organization"
+    }]
+  rescue Aws::Organizations::Errors::AWSOrganizationsNotInUseException
+    # Exception is thrown when the account is not already in an organization
+    []
+  end
+end

--- a/lib/geoengineer/resources/aws/organizations/aws_organizations_policy.rb
+++ b/lib/geoengineer/resources/aws/organizations/aws_organizations_policy.rb
@@ -1,0 +1,30 @@
+########################################################################
+# AwsOrganizationsPolicy is the +aws_organizations_policy+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/organizations_policy.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsOrganizationsPolicy < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :content]) }
+
+  after :initialize, -> {
+    _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id }
+  }
+  after :initialize, -> {
+    _geo_id -> { name }
+  }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    response = AwsClients.organizations(provider).list_policies({ filter: "SERVICE_CONTROL_POLICY" })
+    response.policies.map(&:to_h).map do |pol|
+      {
+        _terraform_id: pol[:id],
+        _geo_id: pol[:name],
+        name: pol[:name]
+      }
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/organizations/aws_organizations_policy_attachment.rb
+++ b/lib/geoengineer/resources/aws/organizations/aws_organizations_policy_attachment.rb
@@ -1,0 +1,43 @@
+########################################################################
+# AwsOrganizationsPolicyAttachment is the +aws_organizations_policy_attachment+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/organizations_policy_attachment.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsOrganizationsPolicyAttachment < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:policy_id, :target_id]) }
+
+  after :initialize, -> { _terraform_id -> { "#{target_id}:#{policy_id}" } }
+  after :initialize, -> { _geo_id -> { "#{target_id}:#{policy_id}" } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients
+      .organizations(provider)
+      .list_policies({ filter: "SERVICE_CONTROL_POLICY" })
+      .policies
+      .map(&:to_h)
+      .map { |pol| _generate_attachments(provider, pol) }
+      .flatten
+  end
+
+  def self._generate_attachments(provider, policy)
+    targets =
+      AwsClients
+      .organizations(provider)
+      .list_targets_for_policy({ policy_id: policy[:id] })
+      .targets
+      .map(&:to_h)
+
+    targets.map do |target|
+      {
+        _terraform_id: "#{target[:target_id]}:#{policy[:id]}",
+        _geo_id: "#{target[:target_id]}:#{policy[:id]}",
+        policy_id: policy[:id],
+        target_id: target[:target_id]
+      }
+    end
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -242,4 +242,11 @@ class AwsClients
       Aws::CodeDeploy::Client
     )
   end
+
+  def self.organizations(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::Organizations::Client
+    )
+  end
 end

--- a/spec/resources/aws_organizations_account_spec.rb
+++ b/spec/resources/aws_organizations_account_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsOrganizationsAccount do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    let(:organizations) { AwsClients.organizations }
+    before do
+      stub = organizations.stub_data(
+        :list_accounts,
+        {
+          accounts: [
+            { id: 'id1', name: 'name1' },
+            { id: 'id2', name: 'name2' }
+          ]
+        }
+      )
+      organizations.stub_responses(:list_accounts, stub)
+    end
+
+    after do
+      organizations.stub_responses(:list_accounts, [])
+    end
+
+    it 'should create a list of accounts from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsOrganizationsAccount._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 2
+    end
+  end
+end

--- a/spec/resources/aws_organizations_organization_spec.rb
+++ b/spec/resources/aws_organizations_organization_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsOrganizationsOrganization) do
+  describe "class mapping" do
+    mapping_tests(described_class, described_class.type_from_class_name)
+  end
+
+  describe "#_fetch_remote_resources" do
+    let(:organizations) { AwsClients.organizations }
+    before do
+      stub = organizations.stub_data(
+        :describe_organization,
+        {
+          organization: { id: 'name1' }
+        }
+      )
+      organizations.stub_responses(:describe_organization, stub)
+    end
+
+    after do
+      organizations.stub_responses(:describe_organization, {})
+    end
+
+    it 'should create an organization hash from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsOrganizationsOrganization
+                         ._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(1)
+    end
+  end
+end

--- a/spec/resources/aws_organizations_policy_attachment_spec.rb
+++ b/spec/resources/aws_organizations_policy_attachment_spec.rb
@@ -1,0 +1,41 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsOrganizationsPolicyAttachment) do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    let(:organizations) { AwsClients.organizations }
+    before do
+      stub1 = organizations.stub_data(
+        :list_policies,
+        {
+          policies: [
+            { id: 'name1' },
+            { id: 'name2' }
+          ]
+        }
+      )
+      stub2 = organizations.stub_data(
+        :list_targets_for_policy,
+        {
+          targets: [
+            { target_id: 'name3' }
+          ]
+        }
+      )
+      organizations.stub_responses(:list_policies, stub1)
+      organizations.stub_responses(:list_targets_for_policy, stub2)
+    end
+
+    after do
+      organizations.stub_responses(:list_policies, [])
+      organizations.stub_responses(:list_targets_for_policy, [])
+    end
+
+    it 'should create list of attachments from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsOrganizationsPolicyAttachment
+                         ._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end

--- a/spec/resources/aws_organizations_policy_spec.rb
+++ b/spec/resources/aws_organizations_policy_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsOrganizationsPolicy do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    let(:organizations) { AwsClients.organizations }
+    before do
+      stub = organizations.stub_data(
+        :list_policies,
+        {
+          policies: [
+            { id: 'id1', name: 'name1' },
+            { id: 'id2', name: 'name2' }
+          ]
+        }
+      )
+      organizations.stub_responses(:list_policies, stub)
+    end
+
+    after do
+      organizations.stub_responses(:list_policies, [])
+    end
+
+    it 'should create a list of policies from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsOrganizationsPolicy._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
This adds support for the following resource types:

* aws_organizations_organization
* aws_organizations_account
* aws_organizations_policy
* aws_organizations_policy_attachment

These are used to create a child account within an AWS Organization
programmatically, as well as to create service control policies within the
organization which define a top level definitions of actions that are allowed
within child accounts.