### PR TITLE
Remove an errant pry require statement.

### DIFF
--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -1,5 +1,4 @@
 require 'yaml'
-require 'pry'
 ###
 # GPS Geo Planning System
 # This module is designed as a higher abstration above the "resources" level


### PR DESCRIPTION
This removes a likely errant pry require statement. Currently, pry is simply
listed as a dev dependency, however part of GPS was importing it directly.