### PR TITLE
Update terraform_id/geo_id handling on aws_rds_cluster_endpoint

### DIFF
--- a/lib/geoengineer/resources/aws/rds/aws_rds_cluster_endpoint.rb
+++ b/lib/geoengineer/resources/aws/rds/aws_rds_cluster_endpoint.rb
@@ -14,15 +14,8 @@ class GeoEngineer::Resources::AwsRdsClusterEndpoint < GeoEngineer::Resource
     )
   }
 
-  after :initialize, -> { _terraform_id -> { cluster_identifier } }
-
-  def to_terraform_state
-    tfstate = super
-    tfstate[:primary][:attributes] = {
-      'cluster_identifier' => _terraform_id
-    }
-    tfstate
-  end
+  after :initialize, -> { _terraform_id -> { cluster_endpoint_identifier } }
+  after :initialize, -> { _geo_id -> { cluster_endpoint_identifier } }
 
   def short_type
     'rds_cluster_endpoint'
@@ -34,8 +27,8 @@ class GeoEngineer::Resources::AwsRdsClusterEndpoint < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     AwsClients.rds(provider).describe_db_cluster_endpoints['db_cluster_endpoints'].map(&:to_h).map do |endpoint|
-      endpoint[:_terraform_id] = endpoint[:db_cluster_identifier]
-      endpoint[:_geo_id] = endpoint[:db_cluster_identifier]
+      endpoint[:_terraform_id] = endpoint[:db_cluster_endpoint_identifier]
+      endpoint[:_geo_id] = endpoint[:cluster_endpoint_identifier]
       endpoint[:cluster_identifier] = endpoint[:db_cluster_identifier]
       endpoint
     end

--- a/spec/resources/aws_rds_cluster_endpoint_spec.rb
+++ b/spec/resources/aws_rds_cluster_endpoint_spec.rb
@@ -10,8 +10,8 @@ describe GeoEngineer::Resources::AwsRdsClusterEndpoint do
         :describe_db_cluster_endpoints,
         {
           db_cluster_endpoints: [
-            { db_cluster_identifier: 'name1' },
-            { db_cluster_identifier: 'name2' }
+            { db_cluster_endpoint_identifier: 'name1' },
+            { db_cluster_endpoint_identifier: 'name2' }
           ]
         }
       )


### PR DESCRIPTION
This updates the handling for the terraform_id and geo_id in the
`aws_rds_cluster_endpoint` resource. This was being set to the cluster's
identifier, however this wouldn't work when using the resource for custom
endpoints, as it would create the resources, but then on the next run see them
as missing and then fail on the apply.

The resource can only really be used for custom endpoints and not for the built
in default reader/write, from the looks of the Terraform code. On those, AWS
doesn't return a `db_cluster_endpoint_identifier`, but those ones can't really
be altered within Terraform anyway.