### PR TITLE
Adds some additional resources around IAM

### DIFF
--- a/lib/geoengineer/resources/aws/iam/aws_iam_account_alias.rb
+++ b/lib/geoengineer/resources/aws/iam/aws_iam_account_alias.rb
@@ -1,0 +1,23 @@
+########################################################################
+# AwsIamAccountAlias +aws_iam_account_alias+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/iam_account_alias.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsIamAccountAlias < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:account_alias]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { account_alias.to_s } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    aliases = AwsClients.iam(provider).list_account_aliases['account_aliases'].to_a
+
+    aliases.map do |a|
+      { name: a, _geo_id: a, _terraform_id: a }
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/iam/aws_iam_group_policy.rb
+++ b/lib/geoengineer/resources/aws/iam/aws_iam_group_policy.rb
@@ -1,0 +1,64 @@
+########################################################################
+# AwsIamGroupPolicy +aws_iam_group_policy+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/iam_group_policy.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsIamGroupPolicy < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :policy, :group]) }
+  validate -> { validate_policy_length(self.policy) }
+
+  after :initialize, -> {
+    _terraform_id -> { "#{group}:#{name}" }
+  }
+
+  def to_terraform_state
+    tfstate = super
+    attributes = {
+      'policy' => policy,
+      'group' => group,
+      'name' => name
+    }
+
+    tfstate[:primary][:attributes] = attributes
+
+    tfstate
+  end
+
+  def support_tags?
+    false
+  end
+
+  def _policy_file(path, binding_obj = nil)
+    _json_file(:policy, path, binding_obj)
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients
+      .iam(provider)
+      .list_groups
+      .groups
+      .map(&:to_h)
+      .map { |group| _get_group_policies(provider, group) }
+      .flatten
+      .compact
+      .map { |group_policy| _get_policy(provider, group_policy) }
+  end
+
+  def self._get_group_policies(provider, group)
+    AwsClients
+      .iam(provider)
+      .list_group_policies({ group_name: group[:group_name] })
+      .map(&:policy_names)
+      .flatten
+      .map { |policy| { group_name: group[:group_name], policy_name: policy } }
+  end
+
+  def self._get_policy(provider, group_policy)
+    AwsClients
+      .iam(provider)
+      .get_group_policy(group_policy)
+      .to_h
+      .merge({ _terraform_id: "#{group_policy[:group_name]}:#{group_policy[:policy_name]}",
+               _geo_id: "#{group_policy[:group_name]}:#{group_policy[:policy_name]}" })
+  end
+end

--- a/lib/geoengineer/resources/aws/iam/aws_iam_user_policy.rb
+++ b/lib/geoengineer/resources/aws/iam/aws_iam_user_policy.rb
@@ -1,0 +1,64 @@
+########################################################################
+# AwsIamUserPolicy +aws_iam_user_policy+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/iam_user_policy.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsIamUserPolicy < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :policy, :user]) }
+  validate -> { validate_policy_length(self.policy) }
+
+  after :initialize, -> {
+    _terraform_id -> { "#{user}:#{name}" }
+  }
+
+  def to_terraform_state
+    tfstate = super
+    attributes = {
+      'policy' => policy,
+      'user' => user,
+      'name' => name
+    }
+
+    tfstate[:primary][:attributes] = attributes
+
+    tfstate
+  end
+
+  def support_tags?
+    false
+  end
+
+  def _policy_file(path, binding_obj = nil)
+    _json_file(:policy, path, binding_obj)
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients
+      .iam(provider)
+      .list_users
+      .users
+      .map(&:to_h)
+      .map { |user| _get_user_policies(provider, user) }
+      .flatten
+      .compact
+      .map { |user_policy| _get_policy(provider, user_policy) }
+  end
+
+  def self._get_user_policies(provider, user)
+    AwsClients
+      .iam(provider)
+      .list_user_policies({ user_name: user[:user_name] })
+      .map(&:policy_names)
+      .flatten
+      .map { |policy| { user_name: user[:user_name], policy_name: policy } }
+  end
+
+  def self._get_policy(provider, user_policy)
+    AwsClients
+      .iam(provider)
+      .get_user_policy(user_policy)
+      .to_h
+      .merge({ _terraform_id: "#{user_policy[:user_name]}:#{user_policy[:policy_name]}",
+               _geo_id: "#{user_policy[:user_name]}:#{user_policy[:policy_name]}" })
+  end
+end

--- a/lib/geoengineer/resources/aws/organizations/aws_organizations_account.rb
+++ b/lib/geoengineer/resources/aws/organizations/aws_organizations_account.rb
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsOrganizationsAccount < GeoEngineer::Resource
     # on creation and not persisted.
     self.lifecycle {} unless self.lifecycle
     self.lifecycle.ignore_changes ||= []
-    self.lifecycle.ignore_changes |= ["role_name"]
+    self.lifecycle.ignore_changes |= ["role_name", "iam_user_access_to_billing"]
   }
 
   def support_tags?

--- a/lib/geoengineer/utils/has_validations.rb
+++ b/lib/geoengineer/utils/has_validations.rb
@@ -59,7 +59,7 @@ module HasValidations
 
   def validate_policy_length(policy)
     return unless policy.to_s.length >= MAX_POLICY_LENGTH
-    "Policy is too large - must be less than #{MAX_POLICY_LENGTH} characters"
+    "Policy #{name} is too large - currently #{policy.to_s.length}, max length is #{MAX_POLICY_LENGTH}"
   end
 
   # Validates that at least one of the specified attributes is present

--- a/spec/resources/aws_iam_account_alias_spec.rb
+++ b/spec/resources/aws_iam_account_alias_spec.rb
@@ -1,0 +1,29 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsIamAccountAlias do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    let(:iam) { AwsClients.iam }
+    before do
+      stub = iam.stub_data(
+        :list_account_aliases,
+        {
+          account_aliases: [
+            'alias1'
+          ]
+        }
+      )
+      iam.stub_responses(:list_account_aliases, stub)
+    end
+
+    after do
+      iam.stub_responses(:list_account_aliases, [])
+    end
+
+    it 'should create a list of accounts from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsIamAccountAlias._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
This adds a few additional resources around IAM that I was using when
setting up some Organizations entries.

First, adds the aws_iam_account_alias resource, which is used to set up
those nicely named account shortcuts.

Second, adds `aws_iam_{group,user}_policy` to set policies directly on a
user or group. We already had the resource for role policy, these were
literal copy and pastes. The role resource had no tests, potentially
since its an annoying chain to fetch the resources.

Third, updates `aws_organizations_account` to ignore changes for
iam_user_access_to_billing. The field isn't retrievable after creating,
so it will always show as needing to change but requires destroying the
account.

Finally, updated the validation message when a policy is too large to
include the name of the policy and its current size. This was confusing
when recently looking at one case, where it wasn't clear where to look
how much it was off by.