### PR TITLE
Adds support for additional Direct Connect resources.

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_dx_hosted_private_virtual_interface.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_dx_hosted_private_virtual_interface.rb
@@ -1,0 +1,30 @@
+########################################################################
+# AwsDxHostedPrivateVirtualInterface is the +aws_dx_hosted_private_virtual_interface+ terrform resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dx_hosted_private_virtual_interface.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterface < GeoEngineer::Resource
+  validate -> {
+    validate_required_attributes([:address_family, :bgp_asn, :connection_id, :name, :vlan, :owner_account_id])
+  }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.directconnect(provider)
+              .describe_virtual_interfaces['virtual_interfaces'].map(&:to_h).map do |connection|
+      connection.merge(
+        {
+          _terraform_id: connection[:virtual_interface_id],
+          _geo_id: connection[:virtual_interface_name],
+          name: connection[:virtual_interface_name]
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/vpc/aws_dx_hosted_private_virtual_interface_accepter.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_dx_hosted_private_virtual_interface_accepter.rb
@@ -1,0 +1,26 @@
+########################################################################
+# AwsDxHostedPrivateVirtualInterfaceAcceptor is the +aws_dx_hosted_private_virtual_interface_accepter+ terrform
+# resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dx_hosted_private_virtual_interface_accepter.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:virtual_interface_id]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { virtual_interface_id } }
+  after :initialize, -> { _geo_id -> { virtual_interface_id } }
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.directconnect(provider)
+              .describe_virtual_interfaces['virtual_interfaces'].map(&:to_h).map do |connection|
+      connection.merge(
+        {
+          _terraform_id: connection[:virtual_interface_id],
+          _geo_id: connection[:virtual_interface_id],
+          virtual_interface_id: connection[:virtual_interface_id]
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/vpc/aws_dx_lag.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_dx_lag.rb
@@ -1,0 +1,22 @@
+########################################################################
+# AwsDxLag is the +aws_dx_lag+ terrform resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dx_lag.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsDxLag < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :connections_bandwidth, :location]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.directconnect(provider).describe_lags['lags'].map(&:to_h).map do |lag|
+      {
+        _terraform_id: lag[:lag_id],
+        _geo_id: lag[:lag_name],
+        name: lag[:lag_name]
+      }
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/vpc/aws_dx_private_virtual_interface.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_dx_private_virtual_interface.rb
@@ -1,0 +1,25 @@
+########################################################################
+# AwsDxPrivateVirtualInterface is the +aws_dx_private_virtual_interface+ terrform resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dx_private_virtual_interface.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsDxPrivateVirtualInterface < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:address_family, :bgp_asn, :connection_id, :name, :vlan]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.directconnect(provider)
+              .describe_virtual_interfaces['virtual_interfaces'].map(&:to_h).map do |connection|
+      connection.merge(
+        {
+          _terraform_id: connection[:virtual_interface_id],
+          _geo_id: connection[:virtual_interface_name],
+          name: connection[:virtual_interface_name]
+        }
+      )
+    end
+  end
+end

--- a/spec/resources/aws_dx_hosted_private_virtual_interface_accepter_spec.rb
+++ b/spec/resources/aws_dx_hosted_private_virtual_interface_accepter_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor) do
+  let(:aws_client) { AwsClients.directconnect }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_virtual_interfaces,
+        {
+          virtual_interfaces: [
+            { virtual_interface_id: 'id1' },
+            { virtual_interface_id: 'id2' }
+          ]
+        }
+      )
+    end
+
+    after do
+      aws_client.stub_responses(:describe_virtual_interfaces, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end

--- a/spec/resources/aws_dx_hosted_private_virtual_interface_spec.rb
+++ b/spec/resources/aws_dx_hosted_private_virtual_interface_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterface) do
+  let(:aws_client) { AwsClients.directconnect }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_virtual_interfaces,
+        {
+          virtual_interfaces: [
+            { virtual_interface_id: 'id1', virtual_interface_name: 'name1', owner_account: "1" },
+            { virtual_interface_id: 'id2', virtual_interface_name: 'name2', owner_account: "2" }
+          ]
+        }
+      )
+    end
+
+    after do
+      aws_client.stub_responses(:describe_virtual_interfaces, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterface._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end

--- a/spec/resources/aws_dx_lag_spec.rb
+++ b/spec/resources/aws_dx_lag_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsDxLag) do
+  let(:aws_client) { AwsClients.directconnect }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_lags,
+        {
+          lags: [
+            { lag_id: 'id1', lag_name: 'name1' },
+            { lag_id: 'id2', lag_name: 'name2' }
+          ]
+        }
+      )
+    end
+
+    after do
+      aws_client.stub_responses(:describe_lags, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsDxLag._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end

--- a/spec/resources/aws_dx_private_virtual_interface_spec.rb
+++ b/spec/resources/aws_dx_private_virtual_interface_spec.rb
@@ -1,0 +1,30 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsDxPrivateVirtualInterface) do
+  let(:aws_client) { AwsClients.directconnect }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_virtual_interfaces,
+        {
+          virtual_interfaces: [
+            { virtual_interface_id: 'id1', virtual_interface_name: 'name1' },
+            { virtual_interface_id: 'id2', virtual_interface_name: 'name2' }
+          ]
+        }
+      )
+    end
+
+    after do
+      aws_client.stub_responses(:describe_virtual_interfaces, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsDxPrivateVirtualInterface._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This adds additional support for link aggregation groups (LAGs) and private
virtual interfaces.

The hosted virtual interfaces are two support interfaces across accounts, where
one account own the Direct Connect hook up, but is linking to a VPC in another
account. The "acceptor" resource is used on the side with the VPC being
connected to.