### PR TITLE
API Gateway resource geo ids should be based on the resource's full path

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -51,8 +51,11 @@ module GeoEngineer::ApiGatewayHelpers
                                         rest_api_id: rr[:_terraform_id]
                                       })['items'].map(&:to_h).map do |res|
         next nil unless res[:path_part] # default resource has no path_part
+
+        # The geo id is the full path of the resource, anchored at the root API gateway, with slashes
+        # replaced with a double colon delimiter.
         res[:_terraform_id] = res[:id]
-        res[:_geo_id]       = "#{rr[:_geo_id]}::#{res[:path_part]}"
+        res[:_geo_id]       = "#{rr[:_geo_id]}#{res[:path].gsub('/', '::')}"
         res
       end.compact
     end


### PR DESCRIPTION
Geoengineer does not recognize API Gateway resources it has created because it does not consider the parent when recreating the geo ids of remote resources. This PR changes the geo id scheme to be the full resource path delimited by double colons, so geo is guaranteed to be able to relate remote resources to defined resources while ensuring that resources with the same name but different parents do not conflict.