### PR TITLE
[FIX] Allow for meta meta nodes

### DIFF
--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -194,8 +194,7 @@ class GeoEngineer::GPS
           nodes.each_pair do |node_type, node_names|
             node_names.each_pair do |node_name, attributes|
               node_type_class = find_node_class(node_type)
-              node = node_type_class.new(project, environment, configuration, node_name, attributes)
-              yield environments, configurations, nodes, node_names, node
+              yield node_type_class.new(project, environment, configuration, node_name, attributes)
             end
           end
         end
@@ -203,58 +202,65 @@ class GeoEngineer::GPS
     end
   end
 
-  def expand_meta_nodes(projects_hash)
-    # Bit of a hack just execute expand thre times to support meta-meta-meta nodes
-    ret, = expand_meta_node_layer(
-      *expand_meta_node_layer(
-        *expand_meta_node_layer(projects_hash, [])
-      )
-    )
-    ret
+  def expand_meta_node(node)
+    children_nodes = GeoEngineer::GPS.deep_dup(node.build_nodes)
+    children_nodes.reduce(children_nodes.clone) do |expanded, (node_type, node_names)|
+      node_names.reduce(expanded.clone) do |inner_expanded, (node_name, attributes)|
+        node_type_class = find_node_class(node_type)
+        node = node_type_class.new(node.project, node.environment, node.configuration, node_name, attributes)
+        next inner_expanded unless node.meta?
+        deep_merge(inner_expanded, expand_meta_node(node))
+      end
+    end
   end
 
-  def expand_meta_node_layer(projects_hash, previously_built_nodes)
-    all_built_nodes = []
+  def expand_meta_nodes(projects_hash)
     # We dup the original hash because we cannot edit and loop over it at the same time
-    loop_projects_hash(GeoEngineer::GPS.deep_dup(projects_hash)) do |_, _, _, _, node|
+    loop_projects_hash(GeoEngineer::GPS.deep_dup(projects_hash)) do |node|
       next unless node.meta?
       node.validate # ensures that the meta node has expanded and has correct attributes
 
       # find the hash to edit
       nodes = projects_hash.dig(node.project, node.environment, node.configuration)
 
-      GeoEngineer::GPS.deep_dup(node.build_nodes).each_pair do |built_node_type, built_node_names|
-        built_node_names.each_pair do |built_node_name, built_attributes|
-          built_node = Node.new(node.project, node.environment, node.configuration, built_node_name, built_attributes)
-          built_node.node_type = built_node_type
+      # node_type => node_name => attrs
+      built_nodes = expand_meta_node(node)
 
-          add_built_node(nodes, node, built_node, all_built_nodes, previously_built_nodes)
+      built_nodes.each_pair do |built_node_type, built_node_names|
+        nodes[built_node_type] ||= {}
+        built_node_names.each_pair do |built_node_name, built_attributes|
+          # Error if the meta-node is overwriting an existing node
+          already_built_error = "\"#{node.node_name}\" overwrites node \"#{built_node_name}\""
+          raise MetaNodeError, already_built_error if nodes[built_node_type].key?(built_node_name)
+          # append to the hash
+          nodes[built_node_type][built_node_name] = built_attributes
         end
       end
     end
 
-    [projects_hash, (all_built_nodes + previously_built_nodes)]
+    projects_hash
   end
 
-  def add_built_node(nodes, node, built_node, all_built_nodes, previously_built_nodes)
-    return if previously_built_nodes.include?(built_node.node_id)
-    nodes[built_node.node_type] ||= {}
-
-    # Error if the meta-node is overwriting an existing node and not a previously built node
-    already_built_error = "\"#{node.node_name}\" overwrites node \"#{built_node.node_name}\""
-    should_error = nodes[built_node.node_type].key?(built_node.node_name)
-    raise MetaNodeError, already_built_error if should_error
-
-    # append to the hash
-    nodes[built_node.node_type][built_node.node_name] = built_node.attributes
-    all_built_nodes << built_node.node_id
+  def deep_merge(a, b)
+    if a.is_a?(Hash) || b.is_a?(Hash)
+      a ||= {}
+      b ||= {}
+      b.each_with_object(a) do |(key, value), obj|
+        obj[key] = deep_merge(obj[key], value)
+      end
+      a
+    elsif a.is_a?(Array)
+      a.concat(b).flatten.compact.uniq
+    else
+      b
+    end
   end
 
   def build_nodes(projects_hash)
     all_nodes = []
     # This is a lot of assumptions
 
-    loop_projects_hash(projects_hash) do |_, _, _, _, node|
+    loop_projects_hash(projects_hash) do |node|
       all_nodes << node
     end
 

--- a/spec/gps/gps_spec.rb
+++ b/spec/gps/gps_spec.rb
@@ -87,6 +87,16 @@ describe GeoEngineer::GPS do
       expect(g.where("p1:e1:c1:test_meta_node:n1").length).to eq 1
       expect(g.where("p1:e1:c1:test_node:n1").length).to eq 1
     end
+
+    it 'should expand meta nodes which build meta nodes' do
+      g = GeoEngineer::GPS.new({
+                                 "p1" => { "e1" => { "c1" => { "test_meta_meta_node" => { "n1" => {} } } } }
+                               })
+      expect(g.nodes.length).to eq 3
+      expect(g.where("p1:e1:c1:test_meta_meta_node:*").length).to eq 1
+      expect(g.where("p1:e1:c1:test_meta_node:*").length).to eq 1
+      expect(g.where("p1:e1:c1:test_node:*").length).to eq 1
+    end
   end
 
   describe '#expanded_hash' do

--- a/spec/gps/test_nodes.rb
+++ b/spec/gps/test_nodes.rb
@@ -37,7 +37,33 @@ class GeoEngineer::GPS::Nodes::TestMetaNode < GeoEngineer::GPS::MetaNode
     {
       "test_node" => {
         node_name.to_s => {
-          "name" => "awsome_#{attributes['name']}"
+          "name" => "awesome_#{attributes['name']}"
+        }
+      }
+    }
+  end
+end
+
+class GeoEngineer::GPS::Nodes::TestMetaMetaNode < GeoEngineer::GPS::MetaNode
+  def json_schema
+    {
+      "type":  "object",
+      "additionalProperties" => false,
+      "properties":  {
+        "name":  {
+          "type":  "string",
+          "default":  "default"
+        }
+      }
+    }
+  end
+
+  # returns node_type -> node_name -> attrs
+  def build_nodes
+    {
+      "test_meta_node" => {
+        node_name.to_s => {
+          "name" => "such_meta"
         }
       }
     }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 require 'rspec'
 require_relative '../lib/geoengineer'
-require 'pry'
 
 Dir[File.dirname(__FILE__) + '/support/**/*.rb'].each { |f| require f }
 


### PR DESCRIPTION
This refactors the ability of GPS to handle meta nodes which in turn
build other meta nodes.

It does so in a recursive manner, whereas the current approach was
limited to a depth of 3.

It also adds tests for this behavior.