### PR TITLE
[NEW] Add dereferencing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,11 +62,11 @@ Style/WordArray:
 
 Metrics/ClassLength:
   CountComments: false  # count full line comments?
-  Max: 250
+  Max: 300
 
 Metrics/ModuleLength:
   CountComments: false  # count full line comments?
-  Max: 250
+  Max: 300
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -10,12 +10,27 @@ class GeoEngineer::GPS
   class NotFoundError < StandardError; end
   class NotUniqueError < StandardError; end
   class BadQueryError < StandardError; end
+  class BadReferenceError < StandardError; end
   class GPSProjetNotFound < StandardError; end
   class NodeTypeNotFound < StandardError; end
   class MetaNodeError < StandardError; end
   class LoadError < StandardError; end
 
   GPS_FILE_EXTENSTION = ".gps.yml".freeze
+
+  REFERENCE_SYNTAX = %r{
+    ^(?!arn:aws:)                           # Make sure we do not match AWS ARN's
+    (?<project>[a-zA-Z0-9\\-_/*]*):         # Match the project name (optional)
+    (?<environment>[a-zA-Z0-9\\-_*]*):      # Match the environment (optional)
+    (?<configuration>[a-zA-Z0-9\\-_*]*):    # Match the configuration (optional)
+    (?<node_type>[a-zA-Z0-9\\-_]+):         # Match the node_type (required), does not support `*`
+    (?<node_name>[a-zA-Z0-9\\-_/*.]+)       # Match the node_name (required)
+    (                                       # The #<resource>.<attribute> is optional
+      [#](?<resource>[a-zA-Z0-9_]+)         # Match the node resource (optional)
+      ([.](?<attribute>[a-zA-Z0-9_]+))?     # Match the resource attribute, requires resource (optional)
+    )?
+    $
+  }x
 
   ###
   # HASH METHODS
@@ -65,6 +80,40 @@ class GeoEngineer::GPS
   def self.search(nodes, query)
     project, environment, config, node_type, node_name = split_query(query)
     nodes.select { |n| n.match(project, environment, config, node_type, node_name) }
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def self.dereference(nodes, reference)
+    components = reference.match(REFERENCE_SYNTAX)
+    return reference unless components
+
+    nodes = where(nodes, query_from_reference(reference))
+    raise NotFoundError, "for reference: #{reference}" if nodes.empty?
+
+    dereferenced = nodes.map do |node|
+      next node unless components["resource"]
+      node.send("#{components['resource']}_ref", components["attribute"] || 'id')
+    end
+
+    # If the user provided a wildcard query, they expect an array, otherwise they expect an object
+    wildcard_query?(reference) ? dereferenced : dereferenced.first
+  rescue NoMethodError
+    raise BadReferenceError, "for reference #{reference}, unknown resource: #{components['resource']}"
+  end
+
+  def self.wildcard_query?(query)
+    query.include?("*")
+  end
+
+  def self.query_from_reference(reference)
+    components = reference.match(REFERENCE_SYNTAX)
+    [
+      components["project"],
+      components["environment"],
+      components["configuration"],
+      components["node_type"],
+      components["node_name"]
+    ].join(":")
   end
 
   ###
@@ -170,6 +219,10 @@ class GeoEngineer::GPS
 
   def where(query)
     GeoEngineer::GPS.where(@nodes, query)
+  end
+
+  def dereference(reference)
+    GeoEngineer::GPS.dereference(@nodes, reference)
   end
 
   def to_h

--- a/lib/geoengineer/gps/node.rb
+++ b/lib/geoengineer/gps/node.rb
@@ -183,6 +183,10 @@ class GeoEngineer::GPS::Node
     GeoEngineer::GPS.find(all_nodes, build_query(query))
   end
 
+  def dereference(reference)
+    GeoEngineer::GPS.dereference(all_nodes, build_reference(reference))
+  end
+
   # the query can come in with defaults and be filled in
   def build_query(query)
     project, _, configuration, node_type, node_name = query.split(":")
@@ -197,5 +201,10 @@ class GeoEngineer::GPS::Node
     node_name = @node_name         if node_name.to_s == ""
 
     "#{project}:#{@environment}:#{configuration}:#{node_type}:#{node_name}"
+  end
+
+  def build_reference(reference)
+    query, ref = reference.split("#")
+    [build_query(query), ref].compact.join("#")
   end
 end

--- a/spec/gps/gps_spec.rb
+++ b/spec/gps/gps_spec.rb
@@ -131,14 +131,14 @@ describe GeoEngineer::GPS do
       expect(GeoEngineer::GPS.dereference(nodes, "*:*:*:test_node:*")).to eq(nodes)
       expect(GeoEngineer::GPS.dereference(nodes, "p1:*:*:test_node:*")).to eq([n1])
       expect(GeoEngineer::GPS.dereference(nodes, "p2:*:*:test_node:*")).to eq([n2, n3, n4])
-      expect(GeoEngineer::GPS.dereference(nodes, "p2:e2:c2:test_node:n2")).to eq(n4)
+      expect(GeoEngineer::GPS.dereference(nodes, "p2:e2:c2:test_node:n2")).to eq([n4])
     end
 
     it 'returns the designated resource ref' do
       expect(GeoEngineer::GPS.dereference(nodes, "*:*:*:test_node:*#elb")).to eq(nodes.map(&:elb_ref))
       expect(GeoEngineer::GPS.dereference(nodes, "p1:*:*:test_node:*#elb")).to eq([n1.elb_ref])
       expect(GeoEngineer::GPS.dereference(nodes, "p2:*:*:test_node:*#elb")).to eq([n2, n3, n4].map(&:elb_ref))
-      expect(GeoEngineer::GPS.dereference(nodes, "p2:e2:c2:test_node:n2#elb")).to eq(n4.elb_ref)
+      expect(GeoEngineer::GPS.dereference(nodes, "p2:e2:c2:test_node:n2#elb")).to eq([n4.elb_ref])
     end
 
     it 'returns the designated resource attribute ref' do
@@ -149,7 +149,7 @@ describe GeoEngineer::GPS do
       expect(GeoEngineer::GPS.dereference(nodes, "p2:*:*:test_node:*#elb.arn"))
         .to eq([n2, n3, n4].map { |n| n.elb_ref("arn") })
       expect(GeoEngineer::GPS.dereference(nodes, "p2:e2:c2:test_node:n2#elb.arn"))
-        .to eq(n4.elb_ref("arn"))
+        .to eq([n4.elb_ref("arn")])
     end
 
     it 'errors if no matching nodes are found' do

--- a/spec/gps/test_nodes.rb
+++ b/spec/gps/test_nodes.rb
@@ -13,6 +13,9 @@ class GeoEngineer::GPS::Nodes::TestNode < GeoEngineer::GPS::Node
     }
   end
 
+  # This node doesn't actually have a file associated
+  def load_gps_file; end
+
   def create_resources(project)
     create_elb(project)
   end


### PR DESCRIPTION
This adds the ability to use node references with a GPS file.

Often it is useful to refer some specific attribute of a resource
created by a node, for example a KMS key ARN.

Currently, you can only reference the KMS node, and so other consuming
nodes would have to hardcode the attribute extraction logic.

This works ok, but breaks down when used for things like policies, where
the reference is being substituted into a JSON document. For this, the
user needs to be explicit about which resource and which attribute.

This PR adds that capability, with the syntax:
`<project>:<environment>:<configuration>:<node_type>:<node_name>#<resource>.<attribute>`

And generates the appropriate terraform reference.

If no resource is specified, it returns the node itself. This can be
useful if you need to access the nodes attributes, or something that
can't be expressed via terraform references.