### PR TITLE
Complete AwsApiGatewayModel Interface

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_model.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_model.rb
@@ -1,7 +1,7 @@
 require_relative "./helpers"
 
 ########################################################################
-# AwsCloudTrail is the +api_gatewat_rest_api+ terrform resource,
+# AwsApiGatewayModel is the +api_gateway_model+ terrform resource,
 #
 # {https://www.terraform.io/docs/providers/aws/r/api_gateway_model.html}
 ########################################################################
@@ -10,10 +10,15 @@ class GeoEngineer::Resources::AwsApiGatewayModel < GeoEngineer::Resource
 
   validate -> { validate_required_attributes([:rest_api_id, :name, :content_type, :schema]) }
 
+  after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { rand(36**20).to_s(36) } }
+  after :initialize, -> { _geo_id -> { "#{_rest_api._geo_id}::#{name}" } }
 
   def support_tags?
     false
+  end
+
+  def self._fetch_remote_resources(provider)
+    _remote_rest_api_models(provider) { |_, model| model }.flatten.compact
   end
 end

--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -106,5 +106,25 @@ module GeoEngineer::ApiGatewayHelpers
     rescue Aws::APIGateway::Errors::NotFoundException
       return nil
     end
+
+    # Models
+    def _fetch_remote_rest_api_models(provider, rest_api)
+      resources = _client(provider).get_models(
+        { rest_api_id: rest_api[:_terraform_id] }
+      )['items']
+      resources.map(&:to_h).map do |mod|
+        mod[:_terraform_id] = mod[:id]
+        mod[:_geo_id]       = "#{rest_api[:_geo_id]}::#{mod[:name]}"
+        mod
+      end.compact
+    end
+
+    def _remote_rest_api_models(provider)
+      _fetch_remote_rest_apis(provider).map do |rr|
+        _fetch_remote_rest_api_models(provider, rr) do |model|
+          yield rr, model
+        end
+      end
+    end
   end
 end

--- a/spec/resources/aws_api_gateway_model_spec.rb
+++ b/spec/resources/aws_api_gateway_model_spec.rb
@@ -1,6 +1,81 @@
 require_relative '../spec_helper'
+require 'securerandom'
 
 describe GeoEngineer::Resources::AwsApiGatewayModel do
   let(:aws_client) { AwsClients.api_gateway }
   before { aws_client.setup_stubbing }
+
+  def create_api_gateway_rest_api(name)
+    {
+      id: SecureRandom.hex,
+      name: name
+    }
+  end
+
+  def create_api_gateway_resource(rest_api_id, path)
+    {
+      id: SecureRandom.hex,
+      parent_id: rest_api_id,
+      path: path
+    }
+  end
+
+  def create_api_gateway_model(name, content_type: 'application/json')
+    {
+      id: SecureRandom.hex,
+      name: name,
+      description: "Model #{SecureRandom.hex}",
+      schema: "{}",
+      content_type: content_type
+    }
+  end
+
+  describe '._fetch_remote_resources' do
+    it 'fetches the expected model resources' do
+      # Create a new Rest API and add some resources
+      rest_api = create_api_gateway_rest_api("TestAPI")
+      api_root_resource = create_api_gateway_resource(rest_api[:id], "/")
+      api_thing_resource = create_api_gateway_resource(rest_api[:id], "/thing")
+
+      # Stub the requests for retrieving the APIs and their resources
+      ag = AwsClients.api_gateway
+      ag.stub_responses(
+        :get_rest_apis,
+        ag.stub_data(
+          :get_rest_apis,
+          { items: [rest_api] }
+        )
+      )
+
+      ag.stub_responses(
+        :get_resources,
+        ag.stub_data(
+          :get_resources,
+          {
+            items: [api_root_resource, api_thing_resource]
+          }
+        )
+      )
+
+      # Create our API model and stub the request to retrieve it
+      result_model = create_api_gateway_model("ResultModel")
+      request_model = create_api_gateway_model("RequestModel")
+      ag.stub_responses(
+        :get_models,
+        ag.stub_data(
+          :get_models,
+          {
+            items: [result_model, request_model]
+          }
+        )
+      )
+
+      models = GeoEngineer::Resources::AwsApiGatewayModel._fetch_remote_resources(nil)
+      expect(models.size).to eq(2)
+
+      model_ids = models.map { |m| m[:id] }
+      expect(model_ids).to include(result_model[:id])
+      expect(model_ids).to include(request_model[:id])
+    end
+  end
 end


### PR DESCRIPTION
This commit completes the implementation of `AwsApiGatewayModel`, previously
this class was missing the `_fetch_remote_resources` implementation and this
produced a `NotImplementedError` when attempting to run `geo plan` against a
plan with such a resource.

It includes two new helper methods, `_fetch_remote_rest_api_models` and
`_remote_rest_api_models` to aid in the implementation of
`_fetch_remote_resources`.