### PR TITLE
Fix class name for resource on hosted Direct Connect interfaces

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_dx_hosted_private_virtual_interface_accepter.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_dx_hosted_private_virtual_interface_accepter.rb
@@ -1,10 +1,10 @@
 ########################################################################
-# AwsDxHostedPrivateVirtualInterfaceAcceptor is the +aws_dx_hosted_private_virtual_interface_accepter+ terrform
+# AwsDxHostedPrivateVirtualInterfaceAccepter is the +aws_dx_hosted_private_virtual_interface_accepter+ terrform
 # resource.
 #
 # {https://www.terraform.io/docs/providers/aws/r/dx_hosted_private_virtual_interface_accepter.html Terraform Docs}
 ########################################################################
-class GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor < GeoEngineer::Resource
+class GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAccepter < GeoEngineer::Resource
   validate -> { validate_required_attributes([:virtual_interface_id]) }
   validate -> { validate_has_tag(:Name) }
 

--- a/spec/resources/aws_dx_hosted_private_virtual_interface_accepter_spec.rb
+++ b/spec/resources/aws_dx_hosted_private_virtual_interface_accepter_spec.rb
@@ -1,6 +1,6 @@
 require_relative '../spec_helper'
 
-describe(GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor) do
+describe(GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAccepter) do
   let(:aws_client) { AwsClients.directconnect }
 
   common_resource_tests(described_class, described_class.type_from_class_name)
@@ -23,7 +23,7 @@ describe(GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor) do
     end
 
     it 'should create list of hashes from returned AWS SDK' do
-      remote_resources = GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAcceptor._fetch_remote_resources(nil)
+      remote_resources = GeoEngineer::Resources::AwsDxHostedPrivateVirtualInterfaceAccepter._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq(2)
     end
   end


### PR DESCRIPTION
This fixes the class name for the
`aws_dx_hosted_private_virtual_interface_accepter` resource. The ruby
file was named `accepter` and all, however the class name was previously
`acceptor`. This was incorrect and didn't catch until looked at it very
closely. :smile: