### PR TITLE
[NEW] Add `--allow-destroy` option on plan

### DIFF
--- a/lib/geoengineer/cli/terraform_commands.rb
+++ b/lib/geoengineer/cli/terraform_commands.rb
@@ -95,7 +95,9 @@ module GeoCLI::TerraformCommands
     command :plan do |c|
       c.syntax = 'geo plan [<geo_files>]'
       c.description = 'Generate and show an execution plan'
+      c.option '--allow-destroy', 'Run the plan with allow_destroy = true, useful for debugging'
       action = lambda do |args, options|
+        env.allow_destroy(true) if options.allow_destroy
         create_terraform_files
         terraform_plan
       end


### PR DESCRIPTION
Often I am running a plan, and it triggers an error:
```
This plan would destroy resource X, but it has prevent destroy = true.

Please fix
```

Then I have to go into the `tmp/environment` directory, modify the
`terraform.tf.json` file to allow destroy on those resources, and
re-run just the terraform plan command from the `./geo plan` output.

Annoying.

This will let me append `--allow-destroy` to a `./geo plan` and more
easily let me see why my plan is failing.

INFRA-2979
