### PR TITLE
Fix ArgumentError With Finder

### DIFF
--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -115,7 +115,7 @@ class GeoEngineer::GPS
   end
 
   def find(query)
-    finder.find(nodes, query)
+    finder.find(query)
   end
 
   def where(query)

--- a/spec/gps/gps_spec.rb
+++ b/spec/gps/gps_spec.rb
@@ -45,6 +45,17 @@ describe GeoEngineer::GPS do
     end
   end
 
+  describe '#find' do
+    it 'proxies the request to the finder' do
+      h = { "org/p1" => { "e1" => { "c1" => { "test_node" => { "n1" => { "name" => "asd" } } } } } }
+      gps = GeoEngineer::GPS.new(h)
+
+      expect do
+        gps.find("p1:e1:*:*:*")
+      end.to raise_error(GeoEngineer::GPS::Finder::NotFoundError)
+    end
+  end
+
   describe '#create_project' do
     it 'creates node resources' do
       h = { "org/p1" => { "e1" => { "c1" => { "test_node" => { "n1" => { "name" => "asd" } } } } } }


### PR DESCRIPTION
Currently, an invalid extra argument is being passed to `find` method. This
results in the following error:

```
ArgumentError: wrong number of arguments (given 2, expected 1)
```

This adds a test to check for this regression in the future and fixes it.