### PR TITLE
Fix Terraform State For API Gateway Models

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_model.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_model.rb
@@ -18,6 +18,15 @@ class GeoEngineer::Resources::AwsApiGatewayModel < GeoEngineer::Resource
     false
   end
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'name' => name,
+      'rest_api_id' => rest_api_id
+    }
+    tfstate
+  end
+
   def self._fetch_remote_resources(provider)
     _remote_rest_api_models(provider) { |_, model| model }.flatten.compact
   end


### PR DESCRIPTION
The current terraform state is missing the `name` and `rest_api_id` attributes
and this causes issues with Terraform. This change ensures that these appear in
the tfstate data as expected.