### PR TITLE
Add Support For aws_api_gateway_request_validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 tmp
 .*.sw*
 Gemfile.lock
+
+# Emacs
+*~
+\#*\#
+.\#*

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_request_validator.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_request_validator.rb
@@ -1,0 +1,33 @@
+require_relative "./helpers"
+
+##########################################################################################
+# AwsApiGatewayRequestValidator is the +api_gateway_request_validator+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/api_gateway_request_validator.html}
+##########################################################################################
+class GeoEngineer::Resources::AwsApiGatewayRequestValidator < GeoEngineer::Resource
+  include GeoEngineer::ApiGatewayHelpers
+
+  validate -> { validate_required_attributes([:rest_api_id, :name]) }
+
+  after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{_rest_api._geo_id}::#{name}" } }
+
+  def support_tags?
+    false
+  end
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'name' => name,
+      'rest_api_id' => rest_api_id
+    }
+    tfstate
+  end
+
+  def self._fetch_remote_resources(provider)
+    _remote_rest_api_request_validators(provider) { |_, rv| rv }.flatten.compact
+  end
+end

--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -126,5 +126,24 @@ module GeoEngineer::ApiGatewayHelpers
         end
       end
     end
+
+    # Request Validators
+    def _fetch_remote_rest_api_request_validators(provider, rest_api)
+      resources = _client(provider).get_request_validators(
+        { rest_api_id: rest_api[:_terraform_id] }
+      )['items']
+      resources.map(&:to_h).map do |rv|
+        rv[:_terraform_id] = rv[:id]
+        rv[:_geo_id]       = "#{rest_api[:_geo_id]}::#{rv[:name]}"
+      end
+    end
+
+    def _remote_rest_api_request_validators(provider)
+      _fetch_remote_rest_apis(provider).map do |rr|
+        _fetch_remote_rest_api_request_validators(provider, rr) do |rv|
+          yield rr, rv
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/api_gateway_helpers.rb
+++ b/spec/helpers/api_gateway_helpers.rb
@@ -1,0 +1,62 @@
+require 'securerandom'
+
+def create_api_gateway_rest_api(name)
+  {
+    id: SecureRandom.hex,
+    name: name
+  }
+end
+
+def create_api_gateway_resource(rest_api_id, path)
+  {
+    id: SecureRandom.hex,
+    parent_id: rest_api_id,
+    path: path
+  }
+end
+
+def create_api_gateway_model(name, content_type: 'application/json')
+  {
+    id: SecureRandom.hex,
+    name: name,
+    description: "Model #{SecureRandom.hex}",
+    schema: "{}",
+    content_type: content_type
+  }
+end
+
+def create_api_gateway_request_validator(name)
+  {
+    id: SecureRandom.hex,
+    name: name
+  }
+end
+
+# Creates an API Gateway and adds some initial route resources to it.
+#
+# @param api_gateway [Aws::APIGateway::Client] API gateway client to which
+#   stubs will be added.
+def create_api_with_resources(api_gateway)
+  # Create a new Rest API and add some resources
+  rest_api = create_api_gateway_rest_api("TestAPI")
+  api_root_resource = create_api_gateway_resource(rest_api[:id], "/")
+  api_thing_resource = create_api_gateway_resource(rest_api[:id], "/thing")
+
+  api_gateway.stub_responses(
+    :get_rest_apis,
+    api_gateway.stub_data(
+      :get_rest_apis,
+      { items: [rest_api] }
+    )
+  )
+
+  api_gateway.stub_responses(
+    :get_resources,
+    api_gateway.stub_data(
+      :get_resources,
+      {
+        items: [api_root_resource, api_thing_resource]
+      }
+    )
+  )
+end

--- a/spec/resources/aws_api_gateway_model_spec.rb
+++ b/spec/resources/aws_api_gateway_model_spec.rb
@@ -1,61 +1,15 @@
 require_relative '../spec_helper'
-require 'securerandom'
+require_relative '../helpers/api_gateway_helpers'
 
 describe GeoEngineer::Resources::AwsApiGatewayModel do
   let(:aws_client) { AwsClients.api_gateway }
   before { aws_client.setup_stubbing }
 
-  def create_api_gateway_rest_api(name)
-    {
-      id: SecureRandom.hex,
-      name: name
-    }
-  end
-
-  def create_api_gateway_resource(rest_api_id, path)
-    {
-      id: SecureRandom.hex,
-      parent_id: rest_api_id,
-      path: path
-    }
-  end
-
-  def create_api_gateway_model(name, content_type: 'application/json')
-    {
-      id: SecureRandom.hex,
-      name: name,
-      description: "Model #{SecureRandom.hex}",
-      schema: "{}",
-      content_type: content_type
-    }
-  end
-
   describe '._fetch_remote_resources' do
     it 'fetches the expected model resources' do
-      # Create a new Rest API and add some resources
-      rest_api = create_api_gateway_rest_api("TestAPI")
-      api_root_resource = create_api_gateway_resource(rest_api[:id], "/")
-      api_thing_resource = create_api_gateway_resource(rest_api[:id], "/thing")
-
       # Stub the requests for retrieving the APIs and their resources
       ag = AwsClients.api_gateway
-      ag.stub_responses(
-        :get_rest_apis,
-        ag.stub_data(
-          :get_rest_apis,
-          { items: [rest_api] }
-        )
-      )
-
-      ag.stub_responses(
-        :get_resources,
-        ag.stub_data(
-          :get_resources,
-          {
-            items: [api_root_resource, api_thing_resource]
-          }
-        )
-      )
+      create_api_with_resources(ag)
 
       # Create our API model and stub the request to retrieve it
       result_model = create_api_gateway_model("ResultModel")

--- a/spec/resources/aws_api_gateway_request_validator_spec.rb
+++ b/spec/resources/aws_api_gateway_request_validator_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper'
+require_relative '../helpers/api_gateway_helpers'
+
+describe GeoEngineer::Resources::AwsApiGatewayRequestValidator do
+  let(:aws_client) { AwsClients.api_gateway }
+  before { aws_client.setup_stubbing }
+
+  describe '._fetch_remote_resources' do
+    it 'fetches the expected model resources' do
+      # Stub the requests for retrieving the APIs and their resources
+      ag = AwsClients.api_gateway
+      create_api_with_resources(ag)
+
+      # Create our request validator and stub the request to retrieve it
+      validator1 = create_api_gateway_request_validator("v1")
+      validator2 = create_api_gateway_request_validator("v2")
+      ag.stub_responses(
+        :get_request_validators,
+        ag.stub_data(
+          :get_request_validators,
+          {
+            items: [validator1, validator2]
+          }
+        )
+      )
+
+      validators = GeoEngineer::Resources::AwsApiGatewayRequestValidator._fetch_remote_resources(nil)
+      expect(validators.size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
Add a new API Gateway resource that will allow defining and using
aws_api_gateway_request_validators.