### PR TITLE
 [REFACTOR] Only raise on `dereference!`

### DIFF
--- a/lib/geoengineer/gps/finder.rb
+++ b/lib/geoengineer/gps/finder.rb
@@ -98,7 +98,7 @@ class GeoEngineer::GPS::Finder
       components["node_name"]
     )
 
-    raise NotFoundError, "for reference: #{reference}" if nodes.empty?
+    return [] if nodes.empty?
     method_name = "#{components['resource']}_ref"
     attribute = components["attribute"] || 'id'
 

--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -95,7 +95,7 @@ class GeoEngineer::GPS
   end
 
   attr_reader :base_hash, :constants
-  def initialize(base_hash, constants)
+  def initialize(base_hash = {}, constants = {})
     # Base Hash is the unedited input, useful for debugging
     @base_hash = base_hash
     @constants = constants

--- a/spec/gps/finder_spec.rb
+++ b/spec/gps/finder_spec.rb
@@ -182,9 +182,8 @@ describe GeoEngineer::GPS::Finder do
           .to eq([n4.elb_ref("arn")])
       end
 
-      it 'errors if no matching nodes are found' do
-        expect { finder.dereference("p3:*:*:test_node:*#elb.arn") }
-          .to raise_error(GeoEngineer::GPS::Finder::NotFoundError)
+      it 'returns an empty array if no matching nodes are found' do
+        expect(finder.dereference("p3:*:*:test_node:*#elb.arn")).to eq([])
       end
 
       it 'errors if the resource does not exist' do


### PR DESCRIPTION
 Right now, both `dereference` and `dereference!` error if nothing is
 found. This will conform to the `!` as broadly used in the Ruby
 community, and also allow us to use `dereference` in all environments
 for gps partials.