### PR TITLE
[FIX] Add to_yaml to Tag objects

### DIFF
--- a/lib/geoengineer/gps/yaml_tag.rb
+++ b/lib/geoengineer/gps/yaml_tag.rb
@@ -57,6 +57,10 @@ class GeoEngineer::GPS::YamlTag
     raise NotImplementedError
   end
 
+  def to_yaml
+    "!#{type.split("::")[1]} #{value}"
+  end
+
   def references
     raise NotImplementedError
   end
@@ -94,6 +98,12 @@ class GeoEngineer::GPS::YamlTag::Flatten < GeoEngineer::GPS::YamlTag
   def to_json(options = nil)
     # to_json -> ruby (for embedded tags) -> flatten -> json
     HashUtils.json_dup(value).flatten.to_json
+  end
+
+  def to_yaml
+    value.map { |v| v.is_a?(GeoEngineer::GPS::YamlTag) ? v.to_yaml : v }.to_json
+
+    "#{type.split("::")[1]} #{value}"
   end
 
   def references

--- a/spec/gps/yaml_tag_spec.rb
+++ b/spec/gps/yaml_tag_spec.rb
@@ -95,4 +95,43 @@ describe GeoEngineer::GPS::YamlTag do
       end
     end
   end
+
+  context 'to_yaml' do
+    it 'serializes to itself' do
+      yaml = <<~HEREDOC
+        ---
+        test: !flatten
+        - !ref constant:e:here
+        - - !ref constant:e:here
+        - !ref constant:e:here
+      HEREDOC
+      expect(YAML.load(yaml).to_yaml).to eq(yaml)
+    end
+  end
+
+  context '==' do
+    it 'returns true if the values are the same' do
+      tag1 = GeoEngineer::GPS::YamlTag.new("tag::ref", "foobarbaz")
+      tag2 = GeoEngineer::GPS::YamlTag.new("tag::ref", "foobarbaz")
+      expect(tag1).to eq(tag2)
+    end
+  end
+
+  context '<=>' do
+    it 'sorts based on tag value' do
+      unsorted = [
+        GeoEngineer::GPS::YamlTag.new("tag::ref", 1),
+        GeoEngineer::GPS::YamlTag.new("tag::ref", 3),
+        GeoEngineer::GPS::YamlTag.new("tag::ref", 2)
+      ]
+
+      sorted = [
+        GeoEngineer::GPS::YamlTag.new("tag::ref", 1),
+        GeoEngineer::GPS::YamlTag.new("tag::ref", 2),
+        GeoEngineer::GPS::YamlTag.new("tag::ref", 3)
+      ]
+
+      expect(unsorted.sort).to eq(sorted)
+    end
+  end
 end


### PR DESCRIPTION
In order for optimization to work, we need to be able preserve the yaml
tags.

This should do that.