### PR TITLE
Fix Request Validator Remote Fetch Bug

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -135,6 +135,7 @@ module GeoEngineer::ApiGatewayHelpers
       resources.map(&:to_h).map do |rv|
         rv[:_terraform_id] = rv[:id]
         rv[:_geo_id]       = "#{rest_api[:_geo_id]}::#{rv[:name]}"
+        rv
       end
     end
 

--- a/spec/resources/aws_api_gateway_request_validator_spec.rb
+++ b/spec/resources/aws_api_gateway_request_validator_spec.rb
@@ -26,6 +26,12 @@ describe GeoEngineer::Resources::AwsApiGatewayRequestValidator do
 
       validators = GeoEngineer::Resources::AwsApiGatewayRequestValidator._fetch_remote_resources(nil)
       expect(validators.size).to eq(2)
+
+      # Verify that we get out what we're expecting
+      expected_validator1 = validator1
+      expected_validator1[:_geo_id] = 'TestAPI::v1'
+      expected_validator1[:_terraform_id] = validator1[:id]
+      expect(validators.first).to eq(expected_validator1)
     end
   end
 end


### PR DESCRIPTION
There was a bug in `_fetch_remote_rest_api_request_validators` where instead of
the final request validator Hash object being returned, the `_geo_id` string for
the request validator was returned. This was causing downstream issues in
provisioning API Gateways with request validators.