### PR TITLE
[FIX] Make sort type agnostic

### DIFF
--- a/lib/geoengineer/gps/yaml_tag.rb
+++ b/lib/geoengineer/gps/yaml_tag.rb
@@ -70,12 +70,16 @@ class GeoEngineer::GPS::YamlTag
   end
 
   def ==(other)
-    value == other.value
+    to_s == other.to_s
   end
 
   def <=>(other)
     return 0 if self == other
-    self.value > other.value ? 1 : -1
+    self.to_s > other.to_s ? 1 : -1
+  end
+
+  def to_s
+    value
   end
 
   def references
@@ -128,6 +132,7 @@ class GeoEngineer::GPS::YamlTag::Flatten < GeoEngineer::GPS::YamlTag
   end
 
   def <=>(other)
+    return 0 unless other.is_a?(self.class) || other.is_a?(Array)
     return 0 if value.size == other.value.size
     value.size > other.value.size ? 1 : -1
   end

--- a/spec/gps/yaml_tag_spec.rb
+++ b/spec/gps/yaml_tag_spec.rb
@@ -133,5 +133,21 @@ describe GeoEngineer::GPS::YamlTag do
 
       expect(unsorted.sort).to eq(sorted)
     end
+
+    it 'works with mixed types' do
+      unsorted = [
+        GeoEngineer::GPS::YamlTag.new("tag::ref", "1"),
+        "3",
+        GeoEngineer::GPS::YamlTag.new("tag::sub", "2{{constant::num}}")
+      ]
+
+      sorted = [
+        GeoEngineer::GPS::YamlTag.new("tag::ref", "1"),
+        GeoEngineer::GPS::YamlTag.new("tag::sub", "2{{constant::num}}"),
+        "3"
+      ]
+
+      expect(unsorted.sort).to eq(sorted)
+    end
   end
 end


### PR DESCRIPTION
We need to ensure that if you have a `!ref` or more likely, a `!sub`
tag mixed in with other normal strings, integers, etc... that it doesn't
error, and allows for comparisons based on the tag value.