### PR TITLE
[FIX] Update GeoID for Route53 Zone

### DIFF
--- a/lib/geoengineer/resources/aws/route53/aws_route53_zone.rb
+++ b/lib/geoengineer/resources/aws/route53/aws_route53_zone.rb
@@ -10,14 +10,14 @@ class GeoEngineer::Resources::AwsRoute53Zone < GeoEngineer::Resource
   after :initialize, -> { _geo_id -> { "#{self._public_or_private}-#{self.name}." } }
 
   def _public_or_private
-    self.vpc_id.nil? ? 'public' : self.vpc_id
+    self.vpc&.vpc_id.nil? ? 'public' : self.vpc.vpc_id
   end
 
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] = {
       'name' => name,
-      'vpc_id' => vpc_id,
+      'vpc_id' => vpc&.vpc_id,
       'force_destroy' => (force_destroy || 'false')
     }
     tfstate


### PR DESCRIPTION
Terraform updated their syntax to define the VPC peering noted here:
https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md

The Geo ID for Route53 Zone used to rely on the old, now deprecated
syntax. This updates the GeoID logic to use the syntax.