### PR TITLE
Fix: API Gateway Resource Terraform State Issues

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_model.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_model.rb
@@ -22,7 +22,7 @@ class GeoEngineer::Resources::AwsApiGatewayModel < GeoEngineer::Resource
     tfstate = super
     tfstate[:primary][:attributes] = {
       'name' => name,
-      'rest_api_id' => rest_api_id
+      'rest_api_id' => _rest_api._terraform_id
     }
     tfstate
   end

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_request_validator.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_request_validator.rb
@@ -22,7 +22,7 @@ class GeoEngineer::Resources::AwsApiGatewayRequestValidator < GeoEngineer::Resou
     tfstate = super
     tfstate[:primary][:attributes] = {
       'name' => name,
-      'rest_api_id' => rest_api_id
+      'rest_api_id' => _rest_api._terraform_id
     }
     tfstate
   end


### PR DESCRIPTION
Currently, terraform is unable to recognize `aws_api_gateway_model` and
`api_gateway_request_validator` resources because their primary attributes are
incorrect, namely they are using a reference to the rest_api object instead of
the terraform_id of the rest API object. This was causing terraform to attempt
to repeatedly recreate resources that already existed.

This change fixes this issue by using the correct identifier for these primary
attributes.