### PR TITLE
[FIX] Remove second call to initial_attributes

### DIFF
--- a/lib/geoengineer/gps/node.rb
+++ b/lib/geoengineer/gps/node.rb
@@ -76,7 +76,6 @@ class GeoEngineer::GPS::Node
     @depends_on = @depends_on.flatten.uniq
 
     @attributes = HashUtils.json_dup(attributes)
-    @initial_attributes = HashUtils.deep_dup(attributes)
   end
 
   def references


### PR DESCRIPTION
Which would set initial_attributes to the fully expanded attributes,
which is _not_ what we want.

I swear I had removed that already. Oh well.