### PR TITLE
Add aws_api_gateway_gateway_response Resource Support

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_gateway_response.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_gateway_response.rb
@@ -1,0 +1,33 @@
+require_relative "./helpers"
+
+##########################################################################################
+# AwsApiGatewayGatewayResponse is the +api_gateway_request_validator+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/api_gateway_gateway_response.html}
+##########################################################################################
+class GeoEngineer::Resources::AwsApiGatewayGatewayResponse < GeoEngineer::Resource
+  include GeoEngineer::ApiGatewayHelpers
+
+  validate -> { validate_required_attributes([:rest_api_id, :response_type]) }
+
+  after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{_rest_api._geo_id}::#{response_type}" } }
+
+  def support_tags?
+    false
+  end
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'response_type' => response_type,
+      'rest_api_id'   => _rest_api._terraform_id
+    }
+    tfstate
+  end
+
+  def self._fetch_remote_resources(provider)
+    _remote_rest_api_gateway_responses(provider) { |_, gr| gr }.flatten.compact
+  end
+end

--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -146,5 +146,25 @@ module GeoEngineer::ApiGatewayHelpers
         end
       end
     end
+
+    # Gateway Responses
+    def _fetch_remote_rest_api_gateway_responses(provider, rest_api)
+      resources = _client(provider).get_gateway_responses(
+        { rest_api_id: rest_api[:_terraform_id] }
+      )['items']
+      resources.map(&:to_h).map do |gr|
+        gr[:_terraform_id] = gr[:id]
+        gr[:_geo_id]       = "#{rest_api[:_geo_id]}::#{gr[:response_type]}"
+        gr
+      end
+    end
+
+    def _remote_rest_api_gateway_responses(provider)
+      _fetch_remote_rest_apis(provider).map do |rr|
+        _fetch_remote_rest_api_gateway_responses(provider, rr) do |gr|
+          yield rr, gr
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/api_gateway_helpers.rb
+++ b/spec/helpers/api_gateway_helpers.rb
@@ -32,6 +32,13 @@ def create_api_gateway_request_validator(name)
   }
 end
 
+def create_api_gateway_gateway_response(response_type, status_code: 400)
+  {
+    response_type: response_type,
+    status_code: status_code.to_s
+  }
+end
+
 # Creates an API Gateway and adds some initial route resources to it.
 #
 # @param api_gateway [Aws::APIGateway::Client] API gateway client to which

--- a/spec/resources/aws_api_gateway_gateway_response.rb
+++ b/spec/resources/aws_api_gateway_gateway_response.rb
@@ -1,0 +1,37 @@
+require_relative '../spec_helper'
+require_relative '../helpers/api_gateway_helpers'
+
+describe GeoEngineer::Resources::AwsApiGatewayGatewayResponse do
+  let(:aws_client) { AwsClients.api_gateway }
+  before { aws_client.setup_stubbing }
+
+  describe '._fetch_remote_resources' do
+    it 'fetches the expected model resources' do
+      # Stub the requests for retrieving the APIs and their resources
+      ag = AwsClients.api_gateway
+      create_api_with_resources(ag)
+
+      # Create our request validator and stub the request to retrieve it
+      response1 = create_api_gateway_gateway_response("BAD REQUEST BODY")
+      response2 = create_api_gateway_gateway_response("EXPIRED TOKEN", { status_code: 403 })
+      ag.stub_responses(
+        :get_gateway_responses,
+        ag.stub_data(
+          :get_gateway_responses,
+          {
+            items: [response1, response2]
+          }
+        )
+      )
+
+      responses = GeoEngineer::Resources::AwsApiGatewayGatewayResponse._fetch_remote_resources(nil)
+      expect(responses.size).to eq(2)
+
+      # Verify that we get out what we're expecting
+      expected_response1 = response1
+      expected_response1[:_geo_id] = 'TestAPI::BAD REQUEST BODY'
+      expected_response1[:_terraform_id] = response1[:id]
+      expect(responses.first).to eq(expected_response1)
+    end
+  end
+end


### PR DESCRIPTION
Add support for customizing gateway responses via the `aws_api_gateway_gateway_response`
resource.