### PR TITLE
Complete AW API Gateway Authorizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Gemfile.lock
 *~
 \#*\#
 .\#*
+
+# IDEA
+.idea

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -22,8 +22,8 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] = {
-        'name' => name,
-        'rest_api_id' => _rest_api._terraform_id
+      'name' => name,
+      'rest_api_id' => _rest_api._terraform_id
     }
     tfstate
   end

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -11,10 +11,24 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
 
   validate -> { validate_required_attributes([:authorizer_uri, :name, :rest_api_id]) }
 
+  after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { name } }
 
   def support_tags?
     false
+  end
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+        'name' => name,
+        'rest_api_id' => _rest_api._terraform_id
+    }
+    tfstate
+  end
+
+  def self._fetch_remote_resources(provider)
+    _remote_rest_api_gateway_authorizers(provider) { |_, rv| rv }.flatten.compact
   end
 end

--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -166,5 +166,24 @@ module GeoEngineer::ApiGatewayHelpers
         end
       end
     end
+
+    def _fetch_remote_rest_api_authorizers(provider, rest_api)
+      resources = _client(provider).get_authorizers(
+          { rest_api_id: rest_api[:_terraform_id] }
+      )['items']
+      resources.map(&:to_h).map do |ga|
+        ga[:_terraform_id] = ga[:id]
+        ga[:_geo_id]       = "#{rest_api[:_geo_id]}::#{ga[:name]}"
+        ga
+      end
+    end
+
+    def _remote_rest_api_gateway_authorizers(provider)
+      _fetch_remote_rest_apis(provider).map do |rr|
+        _fetch_remote_rest_api_authorizers(provider, rr) do |ga|
+          yield rr, ga
+        end
+      end
+    end
   end
 end

--- a/lib/geoengineer/resources/aws/api_gateway/helpers.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/helpers.rb
@@ -169,7 +169,7 @@ module GeoEngineer::ApiGatewayHelpers
 
     def _fetch_remote_rest_api_authorizers(provider, rest_api)
       resources = _client(provider).get_authorizers(
-          { rest_api_id: rest_api[:_terraform_id] }
+        { rest_api_id: rest_api[:_terraform_id] }
       )['items']
       resources.map(&:to_h).map do |ga|
         ga[:_terraform_id] = ga[:id]

--- a/spec/helpers/api_gateway_helpers.rb
+++ b/spec/helpers/api_gateway_helpers.rb
@@ -67,3 +67,10 @@ def create_api_with_resources(api_gateway)
     )
   )
 end
+
+def create_api_gateway_authorizer(name)
+  {
+    id: SecureRandom.hex,
+    name: name
+  }
+end

--- a/spec/resources/aws_api_gateway_authorizer_spec.rb
+++ b/spec/resources/aws_api_gateway_authorizer_spec.rb
@@ -1,6 +1,37 @@
 require_relative '../spec_helper'
+require_relative '../helpers/api_gateway_helpers'
 
 describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
   let(:aws_client) { AwsClients.api_gateway }
   before { aws_client.setup_stubbing }
+
+  describe '._fetch_remote_resources' do
+    it 'fetches the expected model resources' do
+      # Stub the requests for retrieving the APIs and their resources
+      ag = AwsClients.api_gateway
+      create_api_with_resources(ag)
+
+      # Create our request validator and stub the request to retrieve it
+      authorizer1 = create_api_gateway_authorizer("authorizer1")
+      authorizer2 = create_api_gateway_authorizer("authorizer2")
+      ag.stub_responses(
+        :get_authorizers,
+        ag.stub_data(
+          :get_authorizers,
+          {
+            items: [authorizer1, authorizer2]
+          }
+        )
+      )
+
+      authorizers = GeoEngineer::Resources::AwsApiGatewayAuthorizer._fetch_remote_resources(nil)
+      expect(authorizers.size).to eq(2)
+
+      # Verify that we get out what we're expecting
+      expected_authorizer1 = authorizer1
+      expected_authorizer1[:_geo_id] = 'TestAPI::authorizer1'
+      expected_authorizer1[:_terraform_id] = authorizer1[:id]
+      expect(authorizers.first).to eq(expected_authorizer1)
+    end
+  end
 end


### PR DESCRIPTION
Completes the `_fetch_remote_resources` and `to_terraform_state` methods for the `AwsApiGatewayAuthorizer` 

Was able to successfully plan the creation of an authorizer using this branch locally. 