### PR TITLE
Set the authorizer id in terraform if it exists

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
           :resource_id,
           :http_method,
           :authorization,
-          :authorizer
+          :authorizer_id
         ]
       else
         [
@@ -33,7 +33,7 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
 
-  after :initialize, -> { self.authorizer = authorizer if authorizer }
+  after :initialize, -> { self.authorizer_id = _authorizer.to_ref if _authorizer }
 
   after :initialize, -> { self.resource_id = _resource.to_ref }
   after :initialize, -> { depends_on [_rest_api, _resource].map(&:terraform_name) }
@@ -48,13 +48,13 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] =
-      if self.authorizer
+      if self.authorizer_id
         {
           "rest_api_id" => _rest_api._terraform_id,
           "resource_id" => _resource._terraform_id,
           "http_method" => http_method,
           "authorization" => authorization,
-          "authorizer_id" => authorizer.terraform_id
+          "authorizer_id" => _authorizer.terraform_id
         }
       else
         {

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
@@ -10,22 +10,22 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
 
   validate -> {
     required_variables =
-        if ['CUSTOM', 'COGNITO_USER_POOL'].include?(:authorization)
-          [
-            :rest_api_id,
-            :resource_id,
-            :http_method,
-            :authorization,
-            :authorizer
-          ]
-        else
-          [
-            :rest_api_id,
-            :resource_id,
-            :http_method,
-            :authorization
-          ]
-          end
+      if ['CUSTOM', 'COGNITO_USER_POOL'].include?(:authorization)
+        [
+          :rest_api_id,
+          :resource_id,
+          :http_method,
+          :authorization,
+          :authorizer
+        ]
+      else
+        [
+          :rest_api_id,
+          :resource_id,
+          :http_method,
+          :authorization
+        ]
+      end
     validate_required_attributes(required_variables)
   }
 
@@ -50,18 +50,18 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
     tfstate[:primary][:attributes] =
       if self.authorizer
         {
-            "rest_api_id" => _rest_api._terraform_id,
-            "resource_id" => _resource._terraform_id,
-            "http_method" => http_method,
-            "authorization" => authorization,
-            "authorizer_id" => authorizer.terraform_id
+          "rest_api_id" => _rest_api._terraform_id,
+          "resource_id" => _resource._terraform_id,
+          "http_method" => http_method,
+          "authorization" => authorization,
+          "authorizer_id" => authorizer.terraform_id
         }
       else
         {
-            "rest_api_id" => _rest_api._terraform_id,
-            "resource_id" => _resource._terraform_id,
-            "http_method" => http_method,
-            "authorization" => authorization
+          "rest_api_id" => _rest_api._terraform_id,
+          "resource_id" => _resource._terraform_id,
+          "http_method" => http_method,
+          "authorization" => authorization
         }
       end
     tfstate

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
@@ -9,17 +9,31 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
   include GeoEngineer::ApiGatewayHelpers
 
   validate -> {
-    validate_required_attributes([
-                                   :rest_api_id,
-                                   :resource_id,
-                                   :http_method,
-                                   :authorization
-                                 ])
+    required_variables =
+        if ['CUSTOM', 'COGNITO_USER_POOL'].include?(:authorization)
+          [
+            :rest_api_id,
+            :resource_id,
+            :http_method,
+            :authorization,
+            :authorizer
+          ]
+        else
+          [
+            :rest_api_id,
+            :resource_id,
+            :http_method,
+            :authorization
+          ]
+          end
+    validate_required_attributes(required_variables)
   }
 
   # Must pass the rest_api as _rest_api resource for additional information
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _rest_api.api_resources[self._type][self.id] = self }
+
+  after :initialize, -> { self.authorizer = authorizer if authorizer }
 
   after :initialize, -> { self.resource_id = _resource.to_ref }
   after :initialize, -> { depends_on [_rest_api, _resource].map(&:terraform_name) }
@@ -33,12 +47,23 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
 
   def to_terraform_state
     tfstate = super
-    tfstate[:primary][:attributes] = {
-      "rest_api_id" => _rest_api._terraform_id,
-      "resource_id" => _resource._terraform_id,
-      "http_method" => http_method,
-      "authorization" => authorization
-    }
+    tfstate[:primary][:attributes] =
+      if self.authorizer
+        {
+            "rest_api_id" => _rest_api._terraform_id,
+            "resource_id" => _resource._terraform_id,
+            "http_method" => http_method,
+            "authorization" => authorization,
+            "authorizer_id" => authorizer.terraform_id
+        }
+      else
+        {
+            "rest_api_id" => _rest_api._terraform_id,
+            "resource_id" => _resource._terraform_id,
+            "http_method" => http_method,
+            "authorization" => authorization
+        }
+      end
     tfstate
   end
 

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_method.rb
@@ -48,7 +48,7 @@ class GeoEngineer::Resources::AwsApiGatewayMethod < GeoEngineer::Resource
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] =
-      if self.authorizer_id
+      if self.authorizer_id && ['CUSTOM', 'COGNITO_USER_POOL'].include?(authorization)
         {
           "rest_api_id" => _rest_api._terraform_id,
           "resource_id" => _resource._terraform_id,

--- a/spec/resources/aws_api_gateway_method_spec.rb
+++ b/spec/resources/aws_api_gateway_method_spec.rb
@@ -1,6 +1,60 @@
 require_relative '../spec_helper'
 
 describe GeoEngineer::Resources::AwsApiGatewayMethod do
-  let(:aws_client) { AwsClients.api_gateway }
-  before { aws_client.setup_stubbing }
+  describe '#to_terraform_state' do
+    it 'terraform state should not have an authorizer id key' do
+
+      test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
+        name        "test"
+      }
+
+      test_resource = GeoEngineer::Resources::AwsApiGatewayResource.new("aws_api_gateway_resource", "test_resource") {
+        _rest_api     test_api
+        _parent       test_api.root_resource
+        path_part     "test"
+      }
+
+
+
+      method = GeoEngineer::Resources::AwsApiGatewayMethod.new("aws_api_gateway_method", "test_method") {
+        _rest_api     test_api
+        _resource     test_resource
+        http_method   "GET"
+        authorization "NONE"
+      }
+
+      terraform_method = method.to_terraform_state
+      expect(terraform_method[:primary][:attributes].has_key?("authorizer_id")).to be_falsey
+    end
+
+    it 'terraform state should have an authorizer id key' do
+
+      test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
+        name        "test"
+      }
+
+      test_resource = GeoEngineer::Resources::AwsApiGatewayResource.new("aws_api_gateway_resource", "test_resource") {
+        _rest_api     test_api
+        _parent       test_api.root_resource
+        path_part     "test"
+      }
+
+      test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_authorizer") {
+        name              "test_authorizer"
+        _rest_api         test_api
+        authorizer_uri    "https://test_url.com"
+      }
+
+      method = GeoEngineer::Resources::AwsApiGatewayMethod.new("aws_api_gateway_method", "test_method") {
+        _rest_api     test_api
+        _resource     test_resource
+        http_method   "GET"
+        authorization "CUSTOM"
+        _authorizer   test_authorizer
+      }
+
+      terraform_method = method.to_terraform_state
+      expect(terraform_method[:primary][:attributes].has_key?("authorizer_id")).to be_truthy
+    end
+  end
 end

--- a/spec/resources/aws_api_gateway_method_spec.rb
+++ b/spec/resources/aws_api_gateway_method_spec.rb
@@ -3,9 +3,8 @@ require_relative '../spec_helper'
 describe GeoEngineer::Resources::AwsApiGatewayMethod do
   describe '#to_terraform_state' do
     it 'terraform state should not have an authorizer id key' do
-
       test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
-        name        "test"
+        name "test"
       }
 
       test_resource = GeoEngineer::Resources::AwsApiGatewayResource.new("aws_api_gateway_resource", "test_resource") {
@@ -13,8 +12,6 @@ describe GeoEngineer::Resources::AwsApiGatewayMethod do
         _parent       test_api.root_resource
         path_part     "test"
       }
-
-
 
       method = GeoEngineer::Resources::AwsApiGatewayMethod.new("aws_api_gateway_method", "test_method") {
         _rest_api     test_api
@@ -24,13 +21,12 @@ describe GeoEngineer::Resources::AwsApiGatewayMethod do
       }
 
       terraform_method = method.to_terraform_state
-      expect(terraform_method[:primary][:attributes].has_key?("authorizer_id")).to be_falsey
+      expect(terraform_method[:primary][:attributes].key?("authorizer_id")).to be_falsey
     end
 
     it 'terraform state should have an authorizer id key' do
-
       test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
-        name        "test"
+        name "test"
       }
 
       test_resource = GeoEngineer::Resources::AwsApiGatewayResource.new("aws_api_gateway_resource", "test_resource") {
@@ -39,7 +35,7 @@ describe GeoEngineer::Resources::AwsApiGatewayMethod do
         path_part     "test"
       }
 
-      test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_authorizer") {
+      test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_auth") {
         name              "test_authorizer"
         _rest_api         test_api
         authorizer_uri    "https://test_url.com"
@@ -54,7 +50,7 @@ describe GeoEngineer::Resources::AwsApiGatewayMethod do
       }
 
       terraform_method = method.to_terraform_state
-      expect(terraform_method[:primary][:attributes].has_key?("authorizer_id")).to be_truthy
+      expect(terraform_method[:primary][:attributes].key?("authorizer_id")).to be_truthy
     end
   end
 end


### PR DESCRIPTION
Applies are failing for api gateway methods that specify an authorization type that requires an authorizer id. Geo wasn't previously setting an authorizer id in the to_terraform_state method. 