### PR TITLE
Breck/add auth uri

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -25,13 +25,13 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
     if authorizer_uri
       {
         'name' => name,
-        'rest_api_id' => _rest_api._terraform_id
+        'rest_api_id' => _rest_api._terraform_id,
+        'authorizer_uri' => authorizer_uri
       }
     else
       {
         'name' => name,
-        'rest_api_id' => _rest_api._terraform_id,
-        'auhtorizer_uri' => authorizer_uri,
+        'rest_api_id' => _rest_api._terraform_id
       }
     end
 

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -9,7 +9,7 @@ require_relative "./helpers"
 class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
   include GeoEngineer::ApiGatewayHelpers
 
-  validate -> { validate_required_attributes([:authorizer_uri, :name, :rest_api_id]) }
+  validate -> { validate_required_attributes([:name, :rest_api_id]) }
 
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
@@ -21,10 +21,20 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
 
   def to_terraform_state
     tfstate = super
-    tfstate[:primary][:attributes] = {
-      'name' => name,
-      'rest_api_id' => _rest_api._terraform_id
-    }
+    tfstate[:primary][:attributes] =
+    if authorizer_uri
+      {
+        'name' => name,
+        'rest_api_id' => _rest_api._terraform_id
+      }
+    else
+      {
+        'name' => name,
+        'rest_api_id' => _rest_api._terraform_id,
+        'auhtorizer_uri' => authorizer_uri,
+      }
+    end
+
     tfstate
   end
 

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -13,7 +13,7 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
 
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { name } }
+  after :initialize, -> { _geo_id -> { "#{_rest_api._geo_id}::#{name}" } }
 
   def support_tags?
     false

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -8,8 +8,8 @@ require_relative "./helpers"
 # TODO: not fully implemented
 class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
   include GeoEngineer::ApiGatewayHelpers
-
-  validate -> { validate_required_attributes([:name, :rest_api_id]) }
+  validate -> { validate_required_attributes([:name, :rest_api_id, :type]) }
+  validate -> { validate_required_attributes([:authorizer_uri]) if ['TOKEN', 'REQUEST'].include?(type) }
 
   after :initialize, -> { self.rest_api_id = _rest_api.to_ref }
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
@@ -22,18 +22,20 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] =
-    if authorizer_uri
-      {
-        'name' => name,
-        'rest_api_id' => _rest_api._terraform_id,
-        'authorizer_uri' => authorizer_uri
-      }
-    else
-      {
-        'name' => name,
-        'rest_api_id' => _rest_api._terraform_id
-      }
-    end
+      if authorizer_uri && ['TOKEN', 'REQUEST'].include?(type)
+        {
+          'name' => name,
+          'rest_api_id' => _rest_api._terraform_id,
+          'type' => type,
+          'authorizer_uri' => authorizer_uri
+        }
+      else
+        {
+          'name' => name,
+          'rest_api_id' => _rest_api._terraform_id,
+          'type' => type
+        }
+      end
 
     tfstate
   end

--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_authorizer.rb
@@ -22,7 +22,7 @@ class GeoEngineer::Resources::AwsApiGatewayAuthorizer < GeoEngineer::Resource
   def to_terraform_state
     tfstate = super
     tfstate[:primary][:attributes] =
-      if authorizer_uri && ['TOKEN', 'REQUEST'].include?(type)
+      if authorizer_uri
         {
           'name' => name,
           'rest_api_id' => _rest_api._terraform_id,

--- a/spec/resources/aws_api_gateway_authorizer_spec.rb
+++ b/spec/resources/aws_api_gateway_authorizer_spec.rb
@@ -52,7 +52,7 @@ describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
       expect(terraform_auth[:primary][:attributes].key?("authorizer_uri")).to be_truthy
     end
 
-    it 'does not include an authorizer_uri key if the type is incorrectly specified' do
+    it 'does not include an authorizer_uri key if not specified' do
       test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
         name "test"
       }

--- a/spec/resources/aws_api_gateway_authorizer_spec.rb
+++ b/spec/resources/aws_api_gateway_authorizer_spec.rb
@@ -36,7 +36,7 @@ describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
   end
 
   describe '#to_terraform_state' do
-    it 'includes an authorizer_id key to terraform state if it is correctly specified' do
+    it 'includes an authorizer_uri key to terraform state if it is correctly specified' do
       test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
         name "test"
       }
@@ -44,6 +44,7 @@ describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
       test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_auth") {
         name              "test_authorizer"
         _rest_api         test_api
+        type              "REQUEST"
         authorizer_uri    "https://test_url.com"
       }
 
@@ -51,7 +52,7 @@ describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
       expect(terraform_auth[:primary][:attributes].key?("authorizer_uri")).to be_truthy
     end
 
-    it 'does not include an authorizer_id key if the authorizer is incorrectly specified' do
+    it 'does not include an authorizer_uri key if the type is incorrectly specified' do
       test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
         name "test"
       }
@@ -59,6 +60,7 @@ describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
       test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_auth") {
         name              "test_authorizer"
         _rest_api         test_api
+        type              "COGNITO_USER_POOLS"
       }
 
       terraform_auth = test_authorizer.to_terraform_state

--- a/spec/resources/aws_api_gateway_authorizer_spec.rb
+++ b/spec/resources/aws_api_gateway_authorizer_spec.rb
@@ -34,4 +34,35 @@ describe GeoEngineer::Resources::AwsApiGatewayAuthorizer do
       expect(authorizers.first).to eq(expected_authorizer1)
     end
   end
+
+  describe '#to_terraform_state' do
+    it 'includes an authorizer_id key to terraform state if it is correctly specified' do
+      test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
+        name "test"
+      }
+
+      test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_auth") {
+        name              "test_authorizer"
+        _rest_api         test_api
+        authorizer_uri    "https://test_url.com"
+      }
+
+      terraform_auth = test_authorizer.to_terraform_state
+      expect(terraform_auth[:primary][:attributes].key?("authorizer_uri")).to be_truthy
+    end
+
+    it 'does not include an authorizer_id key if the authorizer is incorrectly specified' do
+      test_api = GeoEngineer::Resources::AwsApiGatewayRestApi.new("aws_api_gateway_rest_api", "test_api") {
+        name "test"
+      }
+
+      test_authorizer = GeoEngineer::Resources::AwsApiGatewayAuthorizer.new("aws_api_gateway_authorizer", "test_auth") {
+        name              "test_authorizer"
+        _rest_api         test_api
+      }
+
+      terraform_auth = test_authorizer.to_terraform_state
+      expect(terraform_auth[:primary][:attributes].key?("authorizer_uri")).to be_falsey
+    end
+  end
 end


### PR DESCRIPTION
Authorizer URI is not a required attribute for all authorizer types, but is required for TOKEN and REQUEST types. This PR includes the correct validation and terraform state for authorizers to optionally include an authorizer uri when its not required, and validates that it exits when it is required. 