### PR TITLE
Support max_session_duration in aws_iam_role

### DIFF
--- a/lib/geoengineer/resources/aws/iam/aws_iam_role.rb
+++ b/lib/geoengineer/resources/aws/iam/aws_iam_role.rb
@@ -37,7 +37,8 @@ class GeoEngineer::Resources::AwsIamRole < GeoEngineer::Resource
       r.merge({ name: r[:role_name],
                 _geo_id: r[:role_name],
                 _terraform_id: r[:role_name],
-                assume_role_policy: URI.decode(r[:assume_role_policy_document]) })
+                assume_role_policy: URI.decode(r[:assume_role_policy_document]),
+                max_session_duration: r[:max_session_duration] })
     end
   end
 

--- a/spec/resources/aws_iam_role_spec.rb
+++ b/spec/resources/aws_iam_role_spec.rb
@@ -18,7 +18,8 @@ describe GeoEngineer::Resources::AwsIamRole do
               path: "/",
               role_id: "XXXXXXXXXXXXXXXXXXXXY",
               create_date: Time.parse("2016-12-13 01:00:06 UTC"),
-              assume_role_policy_document: ""
+              assume_role_policy_document: "",
+              max_session_duration: 3600
             },
             {
               role_name: 'Another-IAM-role',
@@ -26,7 +27,8 @@ describe GeoEngineer::Resources::AwsIamRole do
               path: "/",
               role_id: "XXXXXXXXXXXXXXXXXXXXY",
               create_date: Time.parse("2016-12-13 01:00:06 UTC"),
-              assume_role_policy_document: ""
+              assume_role_policy_document: "",
+              max_session_duration: 3600
             }
           ]
         }


### PR DESCRIPTION
As documented in the Terraform resource, `max_session_duration` is a key that is supported by `aws_iam_role`, and this adds support for it in Geoengineer.

https://www.terraform.io/docs/providers/aws/r/iam_role.html