### PR TITLE
[FIX] Allow elasticache_subnet_group to plan

### DIFF
--- a/lib/geoengineer/resources/aws/elasticache/aws_elasticache_subnet_group.rb
+++ b/lib/geoengineer/resources/aws/elasticache/aws_elasticache_subnet_group.rb
@@ -8,6 +8,12 @@ class GeoEngineer::Resources::AwsElasticacheSubnetGroup < GeoEngineer::Resource
 
   after :initialize, -> { _terraform_id -> { name } }
 
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = { "name" => name }
+    tfstate
+  end
+
   def support_tags?
     false
   end


### PR DESCRIPTION
It seems Terraform requires the name attribute to be present in order to
refresh the state.