### PR TITLE
Fix tests related to disabling line length rules in a spec.

### DIFF
--- a/spec/resources/aws_vpc_endpoint_service_spec.rb
+++ b/spec/resources/aws_vpc_endpoint_service_spec.rb
@@ -35,3 +35,4 @@ describe(GeoEngineer::Resources::AwsVpcEndpointService) do
     end
   end
 end
+# rubocop:enable Metrics/LineLength


### PR DESCRIPTION
Tests were broken when adding aws_vpc_endpoint_service.