### PR TITLE
adding aws load balancer listener policy and tests

### DIFF
--- a/lib/geoengineer/resources/aws/lb/aws_load_balancer_listener_policy.rb
+++ b/lib/geoengineer/resources/aws/lb/aws_load_balancer_listener_policy.rb
@@ -1,0 +1,48 @@
+########################################################################
+# AwsLoadBalancerListenerPolicy is the +aws_load_balancer_listener_policy+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/load_balancer_listener_policy.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsLoadBalancerListenerPolicy < GeoEngineer::Resource
+  validate -> {
+    validate_required_attributes([:load_balancer_name, :load_balancer_port, :policy_names])
+  }
+
+  after :initialize, -> { _terraform_id -> { "#{load_balancer_name}:#{load_balancer_port}" } }
+  after :initialize, -> { _geo_id -> { "#{load_balancer_name}:#{load_balancer_port}" } }
+
+  def support_tags?
+    false
+  end
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = { load_balancer_port: load_balancer_port.to_s }
+    tfstate
+  end
+
+  def self._merge_attributes(listener_desc, elb)
+    listener = listener_desc[:listener]
+    puts "listener #{listener} load_balancer_port #{listener[:load_balancer_port]}"
+    listener.merge(
+      {
+        _geo_id: "#{elb[:load_balancer_name]}::#{listener[:load_balancer_port]}",
+        _terraform_id: "#{elb[:load_balancer_name]}:#{listener[:load_balancer_port]}",
+        load_balancer_name: elb[:load_balancer_name],
+        load_balancer_port: listener[:load_balancer_port],
+        policy_names: listener_desc[:policy_names]
+      }
+    )
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients
+      .elb(provider)
+      .describe_load_balancers
+      .load_balancer_descriptions
+      .map(&:to_h)
+      .map { |elb| elb[:listener_descriptions].map { |listener_desc| _merge_attributes(listener_desc, elb) } }
+      .flatten
+      .compact
+  end
+end

--- a/spec/resources/aws_load_balancer_listener_policy_spec.rb
+++ b/spec/resources/aws_load_balancer_listener_policy_spec.rb
@@ -1,0 +1,79 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsLoadBalancerListenerPolicy) do
+  let(:elb_client) { AwsClients.elb }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  before { elb_client.setup_stubbing }
+
+  describe "#_fetch_remote_resources" do
+    it 'should create list of hashes from returned AWS SDK' do
+      elb_client.stub_responses(
+        :describe_load_balancer_policies,
+        {
+          policy_descriptions: [
+            {
+              policy_name: "ELBSecurityPolicy-2015-05",
+              policy_type_name: "SSLNegotiationPolicyType"
+            }
+          ]
+        }
+      )
+      elb_client.stub_responses(
+        :describe_load_balancers,
+        {
+          load_balancer_descriptions: [
+            {
+              load_balancer_name: "test",
+              listener_descriptions: [
+                {
+                  listener: {
+                    instance_port: 80,
+                    instance_protocol: "HTTP",
+                    load_balancer_port: 80,
+                    protocol: "HTTP"
+                  },
+                  policy_names: []
+                },
+                {
+                  listener: {
+                    instance_port: 443,
+                    instance_protocol: "HTTPS",
+                    load_balancer_port: 443,
+                    protocol: "HTTPS",
+                    ssl_certificate_id: "arn:aws:iam::123456789012:server-certificate/my-server-cert"
+                  },
+                  policy_names: [
+                    "ELBSecurityPolicy-2015-03"
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      )
+      remote_resources = GeoEngineer::Resources::AwsLoadBalancerListenerPolicy._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 2
+      expect(remote_resources[0]).to include(
+        {
+          load_balancer_name: "test",
+          load_balancer_port: 80,
+          policy_names: [],
+          _geo_id: "test::80",
+          _terraform_id: "test:80"
+        }
+      )
+
+      expect(remote_resources[1]).to include(
+        {
+          load_balancer_name: "test",
+          load_balancer_port: 443,
+          policy_names: ["ELBSecurityPolicy-2015-03"],
+          _geo_id: "test::443",
+          _terraform_id: "test:443"
+        }
+      )
+    end
+  end
+end


### PR DESCRIPTION
The AWS load balancer listener policy resource allows GeoEngineer to set SSL negotiation policies on an ELB's listener. The identifying information for an ELB's listener is combination of the load balancer's name and the load balancer port.