### PR TITLE
[Fix] Select the default provider if not explictly defined

### DIFF
--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -183,7 +183,9 @@ class GeoEngineer::Resource
   # There are two types of provider, the string given to a resource, and the object with attributes
   # this method takes the string on the resource and returns the object
   def fetch_provider
-    environment&.find_provider(provider)
+    # provider is the explictly defined provider
+    # otherwise look at the type to find the default provider, e.g. "aws"
+    environment&.find_provider(provider || _type.split("_").first)
   end
 
   def self.fetch_remote_resources(provider)


### PR DESCRIPTION
If a provider "aws" is selected it should be selected by the resource when fetching remote resources.

e.g.

```
env.provider("aws") {
  region "us-west-1"
}
```

should be the default region for all resources without explicitly defined provider