### PR TITLE
Adds resource for awss_vpc_peering_connection_accepter

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_vpc_peering_connection_accepter.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_vpc_peering_connection_accepter.rb
@@ -1,0 +1,38 @@
+########################################################################
+# AwsVpcPeeringConnection is the +aws_vpc_peering_connection_Accepter+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/vpc_peering_accepter.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsVpcPeeringConnectionAccepter < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:vpc_peering_connection_id]) }
+  validate -> { validate_has_tag(:Name) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { vpc_peering_connection_id } }
+
+  def to_terraform_state
+    tfstate = super
+    tfstate[:primary][:attributes] = {
+      'id' => vpc_peering_connection_id,
+      'vpc_peering_connection_id' => vpc_peering_connection_id
+    }
+    tfstate
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients
+      .ec2(provider)
+      .describe_vpc_peering_connections['vpc_peering_connections']
+      .map(&:to_h)
+      .map { |connection| _merge_ids(connection) }
+  end
+
+  def self._merge_ids(connection)
+    connection.merge(
+      {
+        _terraform_id: connection[:vpc_peering_connection_id],
+        _geo_id: connection[:vpc_peering_connection_id]
+      }
+    )
+  end
+end

--- a/spec/resources/aws_vpc_peering_connection_accepter_spec.rb
+++ b/spec/resources/aws_vpc_peering_connection_accepter_spec.rb
@@ -1,0 +1,31 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::AwsVpcPeeringConnectionAccepter) do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    let(:ec2) { AwsClients.ec2 }
+    before do
+      stub = ec2.stub_data(
+        :describe_vpc_peering_connections,
+        {
+          vpc_peering_connections: [
+            { vpc_peering_connection_id: 'name1', tags: [{ key: 'Name', value: 'one' }] },
+            { vpc_peering_connection_id: 'name1', tags: [{ key: 'Name', value: 'two' }] }
+          ]
+        }
+      )
+      ec2.stub_responses(:describe_vpc_peering_connections, stub)
+    end
+
+    after do
+      ec2.stub_responses(:describe_vpc_peering_connections, [])
+    end
+
+    it 'should create list of hashes from returned AWS SDK' do
+      remote_resources = GeoEngineer::Resources::AwsVpcPeeringConnectionAccepter
+                         ._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
This adds the resource for aws_vpc_peering_connection_accepter, which is needed
in some use cases around cross region peering, where using the non-accepter
resource will create a duplicate resource which enters the failed state once
created.

With this resource, you need to know the connection ID from the requestor side
already, but it is mostly used for Terraform to be able to find and update the
pre-created resource that is pending acceptance.