### PR TITLE
[FIX] Allow falsey values to be dereferenced

### DIFF
--- a/lib/geoengineer/gps/constants.rb
+++ b/lib/geoengineer/gps/constants.rb
@@ -23,10 +23,15 @@ class GeoEngineer::GPS::Constants
     (constants["_global"] || {}).merge(constants[environment_name.to_s])
   end
 
+  # look up in environment then look in the _global
   def dereference(environment, attribute)
-    # look up in environment then look in the _global
-    constants.dig(environment, attribute) ||
-      constants.dig("_global", attribute)
+    from_current_env = constants.dig(environment, attribute)
+    return from_current_env unless from_current_env.nil?
+
+    from_global_env = constants.dig("_global", attribute)
+    return from_global_env unless from_global_env.nil?
+
+    nil
   end
 
   def to_h

--- a/lib/geoengineer/gps/finder.rb
+++ b/lib/geoengineer/gps/finder.rb
@@ -19,7 +19,7 @@ class GeoEngineer::GPS::Finder
     ^
     constant:                             # Hard coding the
     (?<environment>[a-zA-Z0-9\-_*]*):      # Match the environment (optional)
-    (?<attribute>[a-zA-Z0-9\-_/*.]+)       # Match the node_name (required)
+    (?<attribute>[a-zA-Z0-9\-_/?*.]+)       # Match the node_name (required)
     $
   }x
 

--- a/spec/gps/constants_spec.rb
+++ b/spec/gps/constants_spec.rb
@@ -28,6 +28,12 @@ describe GeoEngineer::GPS::Constants do
       c = GeoEngineer::GPS::Constants.new({ "e": { "test": "no" }, "_global": { "test": "hello" } })
       expect(c.dereference("e", "test")).to eq "no"
     end
+
+    it 'works with falsey values' do
+      c = GeoEngineer::GPS::Constants.new({ "e": { "truthy?": true, "falsey?": false } })
+      expect(c.dereference("e", "truthy?")).to eq true
+      expect(c.dereference("e", "falsey?")).to eq false
+    end
   end
 
   context 'yamltags' do


### PR DESCRIPTION
This allows values which equal `false` to be dereferenced.

It also allows `?` to be used in constant names.