### PR TITLE
Add resource for aws_key_pair

### DIFF
--- a/lib/geoengineer/resources/aws/ec2/aws_key_pair.rb
+++ b/lib/geoengineer/resources/aws/ec2/aws_key_pair.rb
@@ -1,0 +1,21 @@
+########################################################################
+# AwsKeyPair is the +aws_key_pair+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/key_pair.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsKeyPair < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:key_name, :public_key]) }
+
+  after :initialize, -> {
+    _terraform_id -> { key_name }
+    _geo_id       -> { key_name }
+
+    self.lifecycle {} unless self.lifecycle
+    self.lifecycle.ignore_changes ||= []
+    self.lifecycle.ignore_changes |= ["public_key", "fingerprint"]
+  }
+
+  def support_tags?
+    false
+  end
+end


### PR DESCRIPTION
This adds a very simple resource for `aws_key_pair`, used to create public keys
for instances in EC2.

The resource doesn't have any tests, since it doesn't leverage any remote
functionality or anything. All there really is on them is the key name and
public key.

This is ignoring changes to `public_key` and `fingerprint`, so any changes to
the key will require you to delete it to apply it. Having either one unignored
would result in it constantly thinking it needed to recreate the resource.

AWS doesn't return the public key, only the fingerprint. We could build the
fingerprint from the public key, and not ignore the fingerprint, but generating
the fingerprint doesn't appear possible with the stdlib in Ruby. It can be done
with `Net::SSH`, but that is adding a dependency for a scarcely used resource.