### PR TITLE
Fix uncodified resource calculation

### DIFF
--- a/lib/geoengineer/environment.rb
+++ b/lib/geoengineer/environment.rb
@@ -197,9 +197,13 @@ class GeoEngineer::Environment
   end
 
   def uncodified_resources(type)
+    local_resources_geo_ids = self.resources_of_type(type).map(&:_geo_id).to_set
+
     # unmanaged resources have a remote resource without local_resource
     clazz = self.class.get_resource_class_from_type(type)
-    res = clazz.fetch_remote_resources(nil).select { |r| r.local_resource.nil? }
+    res = clazz.fetch_remote_resources(nil).select do |r|
+      r._type == type && !local_resources_geo_ids.include?(r._geo_id)
+    end
     res.sort_by(&:terraform_name)
   end
 end

--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -195,7 +195,7 @@ class GeoEngineer::Resource
     return @_rr_cache[provider_id] if @_rr_cache[provider_id]
     @_rr_cache[provider_id] = _fetch_remote_resources(provider)
                               .reject { |resource| _ignore_remote_resource?(resource) }
-                              .map { |resource| GeoEngineer::Resource.build(resource) }
+                              .map { |resource| build(resource) }
   end
 
   # This method must be implemented for each resource type

--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -43,7 +43,6 @@ class GeoEngineer::Resource
     return @_remote if @_remote_searched
     @_remote = _find_remote_resource
     @_remote_searched = true
-    @_remote&.local_resource = self
     @_remote
   end
 


### PR DESCRIPTION
This didn't work because `local_resource` would never be set when running `fetch_remote_resources`, resulting in all resources being considered "uncodified".

I'm not sure where this broke, but I imagine it has something to do with the GPS migration given the overall required to support it.
