### PR TITLE
Filter out Aurora-related databases and parameter groups

### DIFF
--- a/lib/geoengineer/resources/aws/db/aws_db_instance.rb
+++ b/lib/geoengineer/resources/aws/db/aws_db_instance.rb
@@ -41,6 +41,7 @@ class GeoEngineer::Resources::AwsDbInstance < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     dbs = _paginate(AwsClients.rds(provider).describe_db_instances, 'db_instances')
+          .reject { |db| db.engine&.match?(/aurora/i) }
 
     dbs.map(&:to_h).map do |rds|
       rds[:_terraform_id] = rds[:db_instance_identifier]

--- a/lib/geoengineer/resources/aws/db/aws_db_parameter_group.rb
+++ b/lib/geoengineer/resources/aws/db/aws_db_parameter_group.rb
@@ -16,6 +16,7 @@ class GeoEngineer::Resources::AwsDbParameterGroup < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     pgs = _paginate(AwsClients.rds(provider).describe_db_parameter_groups, 'db_parameter_groups')
+          .reject { |db| db.db_parameter_group_family&.match?(/aurora/i) }
 
     pgs.map(&:to_h).map do |pg|
       pg[:_terraform_id] = pg[:db_parameter_group_name]


### PR DESCRIPTION
The `aws_db_instance` and `aws_db_parameter_group` resources were returning Aurora-related resources in addition to vanilla RDS resources.

This throwing off our codification metric as the Aurora-related resources would appear as remote resources but wouldn't have a corresponding local resource.

Fix by filtering out any engine/family mentioning "aurora".
