### PR TITLE
Allow ignoring resources by regex

### DIFF
--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -224,7 +224,15 @@ class GeoEngineer::Resource
   end
 
   def self._ignore_remote_resource?(resource)
-    _resources_to_ignore.include?(_deep_symbolize_keys(resource)[:_geo_id])
+    geo_id = _deep_symbolize_keys(resource)[:_geo_id]
+    _resources_to_ignore.any? do |string_or_regex|
+      case string_or_regex
+      when Regexp
+        geo_id.match?(string_or_regex)
+      else
+        string_or_regex == geo_id
+      end
+    end
   end
 
   def self._deep_symbolize_keys(obj)

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -118,18 +118,18 @@ describe GeoEngineer::Resource do
     it 'lets you ignore certain resources' do
       class GeoEngineer::IgnorableResources < GeoEngineer::Resource
         def self._fetch_remote_resources(provider)
-          [{ _geo_id: "geoid1" }, { _geo_id: "geoid2" }]
+          [{ _geo_id: "geoid1" }, { _geo_id: "geoid2" }, { _geo_id: "anotherid" }, { _geo_id: "otherid" }]
         end
 
         def self._resources_to_ignore
-          ["geoid1"]
+          ["otherid", /^geoid/]
         end
       end
 
       resources = GeoEngineer::IgnorableResources
                   .fetch_remote_resources(GeoEngineer::Provider.new('aws'))
       expect(resources.length).to eq 1
-      expect(resources[0]._geo_id).to eq "geoid2"
+      expect(resources[0]._geo_id).to eq "anotherid"
     end
   end
 


### PR DESCRIPTION
This allows us to ignore classes of resources matching a certain name, which is useful as we move to more resource types being managed outside of code.
