### PR TITLE
Add DAX resources

### DIFF
--- a/lib/geoengineer/resources/aws/dynamodb/aws_dax_cluster.rb
+++ b/lib/geoengineer/resources/aws/dynamodb/aws_dax_cluster.rb
@@ -1,0 +1,26 @@
+########################################################################
+# AwsDaxCluster is the +aws_dax_cluster+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dax_cluster.html}
+########################################################################
+class GeoEngineer::Resources::AwsDaxCluster < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:cluster_name]) }
+
+  after :initialize, -> { _terraform_id -> { name } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def short_type
+    'dax_cluster'
+  end
+
+  def self._fetch_remote_resources(provider)
+    clusters = _paginate(AwsClients.dax(provider).describe_clusters, 'clusters')
+
+    clusters.map(&:to_h).map do |cluster|
+      cluster[:_terraform_id] = cluster[:cluster_name]
+      cluster[:_geo_id]       = cluster[:cluster_name]
+      cluster[:name]          = cluster[:cluster_name]
+      cluster
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/dynamodb/aws_dax_parameter_group.rb
+++ b/lib/geoengineer/resources/aws/dynamodb/aws_dax_parameter_group.rb
@@ -1,0 +1,31 @@
+########################################################################
+# AwsDaxParameterGroup is the +aws_dax_parameter_group+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dax_parameter_group.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsDaxParameterGroup < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
+  validate -> { validate_subresource_required_attributes(:parameter, [:name, :value]) }
+
+  after :initialize, -> { _terraform_id -> { name } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def short_type
+    "daxpg"
+  end
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    pgs = _paginate(AwsClients.dax(provider).describe_parameter_groups, 'parameter_groups')
+
+    pgs.map(&:to_h).map do |pg|
+      pg[:_terraform_id] = pg[:parameter_group_name]
+      pg[:_geo_id] = pg[:parameter_group_name]
+      pg[:name] = pg[:parameter_group_name]
+      pg
+    end
+  end
+end

--- a/lib/geoengineer/resources/aws/dynamodb/aws_dax_subnet_group.rb
+++ b/lib/geoengineer/resources/aws/dynamodb/aws_dax_subnet_group.rb
@@ -1,0 +1,26 @@
+###############################################################################################
+# AwsDaxSubnetGroup is the +aws_dax_subnet_group+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/aws/r/dax_subnet_group.html Terraform Docs}
+##################################################################################################
+class GeoEngineer::Resources::AwsDaxSubnetGroup < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name, :subnet_ids]) }
+
+  after :initialize, -> { _terraform_id -> { name } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    subnet_groups = _paginate(AwsClients.dax(provider).describe_subnet_groups, 'subnet_groups')
+
+    subnet_groups.map(&:to_h).map do |group|
+      group[:name] = group[:subnet_group_name]
+      group[:_terraform_id] = group[:subnet_group_name]
+      group[:_geo_id] = group[:subnet_group_name]
+      group
+    end
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -81,6 +81,13 @@ class AwsClients
     )
   end
 
+  def self.dax(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::DAX::Client
+    )
+  end
+
   def self.dynamo(provider = nil)
     self.client_cache(
       provider,

--- a/spec/resources/aws_dax_cluster_spec.rb
+++ b/spec/resources/aws_dax_cluster_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsDaxCluster do
+  let(:aws_client) { AwsClients.dax }
+
+  before { aws_client.setup_stubbing }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_clusters,
+        {
+          clusters: [
+            { cluster_name: 'test-cluster-1' },
+            { cluster_name: 'test-cluster-2' }
+          ]
+        }
+      )
+    end
+
+    let(:remote_resources) { described_class._fetch_remote_resources(nil) }
+
+    it 'returns the correct number of resources' do
+      expect(remote_resources.length).to eq 2
+    end
+
+    it 'maps cluster group name as the unique identifier' do
+      expect(remote_resources.all? { |res| res['cluster_name'] == res['_geo_id'] && res['cluster_name'] == res['_terraform_id'] }).to eq true # rubocop:disable Metrics/LineLength
+    end
+  end
+end

--- a/spec/resources/aws_dax_parameter_group_spec.rb
+++ b/spec/resources/aws_dax_parameter_group_spec.rb
@@ -1,0 +1,39 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsDaxParameterGroup do
+  let(:aws_client) { AwsClients.dax }
+
+  before { aws_client.setup_stubbing }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_parameter_groups,
+        {
+          parameter_groups: [
+            {
+              parameter_group_name: 'test-parameter-group-1',
+              description: 'A test parameter group'
+            },
+            {
+              parameter_group_name: 'test-parameter-group-2',
+              description: 'Another test parameter group'
+            }
+          ]
+        }
+      )
+    end
+
+    let(:remote_resources) { described_class._fetch_remote_resources(nil) }
+
+    it 'returns the correct number of resources' do
+      expect(remote_resources.length).to eq 2
+    end
+
+    it 'maps parameter group name as the unique identifier' do
+      expect(remote_resources.all? { |res| res['parameter_group_name'] == res['_geo_id'] && res['parameter_group_name'] == res['_terraform_id'] }).to eq true # rubocop:disable Metrics/LineLength
+    end
+  end
+end

--- a/spec/resources/aws_dax_subnet_group_spec.rb
+++ b/spec/resources/aws_dax_subnet_group_spec.rb
@@ -1,0 +1,33 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsDaxSubnetGroup do
+  let(:aws_client) { AwsClients.dax }
+
+  before { aws_client.setup_stubbing }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      aws_client.stub_responses(
+        :describe_subnet_groups,
+        {
+          subnet_groups: [
+            { subnet_group_name: 'test-subnet-group-1' },
+            { subnet_group_name: 'test-subnet-group-2' }
+          ]
+        }
+      )
+    end
+
+    let(:remote_resources) { described_class._fetch_remote_resources(nil) }
+
+    it 'returns the correct number of resources' do
+      expect(remote_resources.length).to eq 2
+    end
+
+    it 'maps subnet group name as the unique identifier' do
+      expect(remote_resources.all? { |res| res['subnet_group_name'] == res['_geo_id'] && res['subnet_group_name'] == res['_terraform_id'] }).to eq true # rubocop:disable Metrics/LineLength
+    end
+  end
+end


### PR DESCRIPTION
Add support for resources related to AWS DAX.

The translation was relatively straightforward. We borrowed implementations from `aws_rds_cluster`, `aws_db_parameter_group`, and `aws_elasticache_subnet_group`.

<!-- The following text is auto-generated from your commit messages -->
### Commit Summary
#### [Add aws_dax_subnet_group resource](https://github.com/coinbase/geoengineer/commit/4dd512b866caed2954e9653d2e22ac1867ad4928)

---
#### [Add aws_dax_parameter_group](https://github.com/coinbase/geoengineer/commit/8ca4bc54d3444f3c970e24e58ca4995cf5ee3a30)

---
#### [Add aws_dax_cluster](https://github.com/coinbase/geoengineer/commit/29fabc668ec20a8b26f9284d2eaa8d7f457f9859)

---
