### PR TITLE
Fixes for aws_kinesis_firehose_delivery_stream and aws_db_parameter_group

### DIFF
--- a/lib/geoengineer/resources/aws/db/aws_db_parameter_group.rb
+++ b/lib/geoengineer/resources/aws/db/aws_db_parameter_group.rb
@@ -16,7 +16,6 @@ class GeoEngineer::Resources::AwsDbParameterGroup < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     pgs = _paginate(AwsClients.rds(provider).describe_db_parameter_groups, 'db_parameter_groups')
-          .reject { |db| db.db_parameter_group_family&.match?(/aurora/i) }
 
     pgs.map(&:to_h).map do |pg|
       pg[:_terraform_id] = pg[:db_parameter_group_name]

--- a/lib/geoengineer/resources/aws/kinesis/aws_kinesis_firehose_delivery_stream.rb
+++ b/lib/geoengineer/resources/aws/kinesis/aws_kinesis_firehose_delivery_stream.rb
@@ -13,7 +13,7 @@ class GeoEngineer::Resources::AwsKinesisFirehoseDeliveryStream < GeoEngineer::Re
   }
 
   def support_tags?
-    false
+    true
   end
 
   def short_type
@@ -36,19 +36,9 @@ class GeoEngineer::Resources::AwsKinesisFirehoseDeliveryStream < GeoEngineer::Re
   end
 
   def self._all_delivery_stream_names(provider)
-    options = { limit: 100 }
-    has_more = true
-    streams = []
-    while has_more
-      resp = AwsClients.firehose(provider)
-                       .list_delivery_streams(options)
-
-      streams += resp.delivery_stream_names
-      has_more = resp.has_more_delivery_streams
-      next unless resp.delivery_stream_names != []
-      options[:exclusive_start_delivery_stream_name] = resp.delivery_stream_names[-1]
-    end
-    streams
+    AwsClients.firehose(provider)
+              .list_delivery_streams
+              .delivery_stream_names
   end
 
   def self._all_delivery_streams(provider, names)


### PR DESCRIPTION
The ruby AWS SDK automatically paginates over resources, remove custom logic. Firehose delivery streams do support tags. We have to use aurora type db parameter groups as rds_cluster_parameter_groups dont support the same feature set.