### PR TITLE
[Fix] v12 terraform requires tags be a single hash

### DIFF
--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -76,6 +76,8 @@ class GeoEngineer::Resource
       json[k] ||= []
       json[k] << v
     end
+
+    json["tags"] = json["tags"].reduce({}, :merge) if json["tags"] # tags not a list
     json
   end
 

--- a/spec/resource_spec.rb
+++ b/spec/resource_spec.rb
@@ -59,7 +59,7 @@ describe GeoEngineer::Resource do
       tfjson = res.to_terraform_json
 
       expect(tfjson['blue']).to eq 'TRUE'
-      expect(tfjson['tags'][0]['not_blue']).to eq 'FALSE'
+      expect(tfjson['tags']['not_blue']).to eq 'FALSE'
       expect(tfjson['lifecycle_rule'][0]['expiration'][0]['days']).to eq 90
       expect(tfjson['lifecycle_rule'][1]['transition'][0]['days']).to eq 60
     end


### PR DESCRIPTION
This PR merges the `tags` subresource into a single hash for the `terraform.json` which is required by terraform v0.12.0 but is backwards compatible with at least v0.11