### PR TITLE
Improve support for efs mount_targets

### DIFF
--- a/lib/geoengineer/resources/aws/efs/aws_efs_mount_target.rb
+++ b/lib/geoengineer/resources/aws/efs/aws_efs_mount_target.rb
@@ -4,17 +4,26 @@
 ## {https://www.terraform.io/docs/providers/aws/d/efs_mount_target.html Terraform Docs}
 #########################################################################
 class GeoEngineer::Resources::AwsEfsMountTarget < GeoEngineer::Resource
-  validate -> { validate_required_attributes([:mount_target_id]) }
+  validate -> { validate_required_attributes([:file_system_id, :subnet_id]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{file_system_id}::#{subnet_id}" } }
+
+  def support_tags?
+    false
+  end
 
   def self._fetch_remote_resources(provider)
-    AwsClients.efs.describe_mount_targets['mount_targets'].map(&:to_h).map do |mount_target|
-      mount_target.merge(
-        {
-          _terraform_id: mount_target["mount_target_id"]
-        }
-      )
-    end
+    AwsClients.efs.describe_file_systems['file_systems'].map(&:to_h).map { |file_system|
+      args = { file_system_id: file_system[:file_system_id] }
+      AwsClients.efs.describe_mount_targets(args)['mount_targets'].map(&:to_h).map do |mount_target|
+        mount_target.merge(
+          {
+            _terraform_id: mount_target[:mount_target_id],
+            _geo_id: "#{mount_target[:file_system_id]}::#{mount_target[:subnet_id]}"
+          }
+        )
+      end
+    }.flatten
   end
 end

--- a/spec/resources/aws_efs_mount_target_spec.rb
+++ b/spec/resources/aws_efs_mount_target_spec.rb
@@ -6,20 +6,35 @@ describe(GeoEngineer::Resources::AwsEfsMountTarget) do
   describe "#_fetch_remote_resources" do
     it 'should create a list of mount targets returned from the AWS sdk' do
       efs = AwsClients.efs
-      stub = efs.stub_data(
-        :describe_mount_targets,
+      file_systems_stub = efs.stub_data(
+        :describe_file_systems,
         {
-          mount_targets: [
+          file_systems: [
             {
-              mount_target_id: "fs-01234567"
-            },
-            {
-              mount_target_id: "fs-89012345"
+              file_system_id: "fs-01234567"
             }
           ]
         }
       )
-      efs.stub_responses(:describe_mount_targets, stub)
+      mount_target_stub = efs.stub_data(
+        :describe_mount_targets,
+        {
+          mount_targets: [
+            {
+              mount_target_id: "fs-01234567",
+              file_system_id: "fs-01234567",
+              subnet_id: "fs-01234567"
+            },
+            {
+              mount_target_id: "fs-89012345",
+              file_system_id: "fs-89012345",
+              subnet_id: "fs-89012345"
+            }
+          ]
+        }
+      )
+      efs.stub_responses(:describe_file_systems, file_systems_stub)
+      efs.stub_responses(:describe_mount_targets, mount_target_stub)
       remote_resources = GeoEngineer::Resources::AwsEfsMountTarget._fetch_remote_resources(nil)
       expect(remote_resources.length).to eq 2
       expect(remote_resources.first[:mount_target_id]).to eq "fs-01234567"


### PR DESCRIPTION
The AWS ruby sdk function describe_mount_targets doesn't return a list of all mount targets. Instead you need to provide the file_system_id for which you want to retrieve all mount targets, which requires a bit of logical refactoring.