### PR TITLE
Add support for alb target group attachments

### DIFF
--- a/lib/geoengineer/resources/aws/lb/aws_alb_target_group_attachment.rb
+++ b/lib/geoengineer/resources/aws/lb/aws_alb_target_group_attachment.rb
@@ -1,0 +1,65 @@
+########################################################################
+# AwsAlbTargetGroupAttachment is the +aws_alb_target_group_attachment+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/aws_alb_target_group_attachment.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsAlbTargetGroupAttachment < GeoEngineer::Resource
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  validate -> { validate_required_attributes([:target_group_arn, :target_id]) }
+
+  before :validation, -> { target_group_arn _target_group.to_ref(:arn) if _target_group }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id       -> { "#{target_group_arn}:#{target_id}" } }
+
+  def support_tags?
+    false
+  end
+
+  def find_remote_as_individual?
+    true
+  end
+
+  def to_terraform_state
+    tfstate = super
+
+    attributes = {}
+    attributes['target_group_arn'] = remote_resource.target_group_arn if remote_resource
+    attributes['target_id'] = target_id
+
+    tfstate[:primary][:attributes] = attributes
+    tfstate
+  end
+
+  def remote_resource_params
+    return {} unless target_id
+    return {} unless _target_group.remote_resource
+
+    arn = _target_group.remote_resource.target_group_arn
+
+    descriptions = AwsClients
+                   .alb(provider)
+                   .describe_target_health({ target_group_arn: arn })
+                   .target_health_descriptions
+                   .map(&:to_h)
+
+    build_remote_resource_params(arn, descriptions)
+  end
+
+  def build_remote_resource_params(arn, descriptions)
+    target = descriptions.find do |description|
+      description.dig(:target, :id) == target_id
+    end
+
+    return {} unless target
+
+    response = {
+      _terraform_id: "#{arn}/#{target_id}",
+      _geo_id: "#{arn}:#{target_id}",
+      target_group_arn: arn,
+      target_id: target_id
+    }
+
+    response
+  end
+end

--- a/lib/geoengineer/resources/aws/lb/aws_lb_listener_rule.rb
+++ b/lib/geoengineer/resources/aws/lb/aws_lb_listener_rule.rb
@@ -15,6 +15,10 @@ class GeoEngineer::Resources::AwsLbListenerRule < GeoEngineer::Resource
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id       -> { "#{listener_arn}::#{priority}" } }
 
+  def support_tags?
+    false
+  end
+
   def short_type
     "lb_listener_rule"
   end

--- a/lib/geoengineer/resources/aws/lb/aws_lb_target_group.rb
+++ b/lib/geoengineer/resources/aws/lb/aws_lb_target_group.rb
@@ -4,15 +4,21 @@
 # {https://www.terraform.io/docs/providers/aws/r/lb_target_group.html Terraform Docs}
 ########################################################################
 class GeoEngineer::Resources::AwsLbTargetGroup < GeoEngineer::Resource
-  validate -> {
-    validate_required_attributes([:name, :port, :protocol, :vpc_id])
-  }
+  validate :validate_target_group_attributes
   validate -> { validate_subresource_required_attributes(:stickiness, [:type]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id       -> { name } }
 
   MAX_RESOURCES_PER_REQUEST = 20
+
+  def validate_target_group_attributes
+    if attributes['target_type'] == 'lambda'
+      validate_required_attributes([:name])
+    else
+      validate_required_attributes([:name, :port, :protocol, :vpc_id])
+    end
+  end
 
   def to_terraform_state
     tfstate = super

--- a/spec/resources/aws_alb_target_group_attachment_spec.rb
+++ b/spec/resources/aws_alb_target_group_attachment_spec.rb
@@ -1,0 +1,85 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAlbTargetGroupAttachment do
+  let(:aws_client) { AwsClients.alb }
+
+  let(:default_lambda_arn) { 'arn:aws:lambda:us-east-1:12345678:function:test-lambda' }
+  let(:default_target_group_arn) { "arn:aws:elasticloadbalancing:us-east-1:12345678:targetgroup/test-tg/c4ae064d" }
+
+  let(:target_group) do
+    GeoEngineer::Resources::AwsAlbTargetGroup.new('aws_alb_target_group', 'target_group') {
+      target_type 'lambda'
+      name 'some target group'
+    }
+  end
+
+  let(:alb_target_group_attachment) do
+    lambda_arn = default_lambda_arn
+    GeoEngineer::Resources::AwsAlbTargetGroupAttachment.new('aws_alb_target_group_attachment', 'attachment') {
+      target_group_arn default_target_group_arn
+      target_id lambda_arn
+      _target_group target_group
+    }
+  end
+
+  # common_resource_tests(described_class, described_class.type_from_class_name, false)
+
+  describe '#remote_resource' do
+    before do
+      aws_client.stub_responses(
+        :describe_target_groups,
+        {
+          "target_groups": [
+            {
+              "health_check_path": "/",
+              "health_check_interval_seconds": 35,
+              "target_group_arn": default_target_group_arn,
+              "target_type": "lambda",
+              "matcher": {
+                "http_code": "200"
+              },
+              "load_balancer_arns": [
+                "arn:aws:elasticloadbalancing:us-east-1:12345678:loadbalancer/app/test/12345abc"
+              ],
+              "healthy_threshold_count": 5,
+              "health_check_timeout_seconds": 30,
+              "health_check_enabled": false,
+              "unhealthy_threshold_count": 2,
+              "target_group_name": "target_group"
+            }
+          ]
+        }
+      )
+      aws_client.stub_responses(
+        :describe_target_health,
+        {
+          "target_health_descriptions": [
+            {
+              "target": {
+                "availability_zone": "all",
+                "id": default_lambda_arn
+              },
+              "target_health": {
+                "state": "unused",
+                "reason": "Target.NotInUse",
+                "description": "Target group is not configured to receive traffic from the load balancer"
+              }
+            }
+          ]
+        }
+      )
+    end
+
+    it 'should create a hash from the response' do
+      expect(target_group).to receive(:target_group_arn).and_return(default_target_group_arn).at_least(:once)
+      expect(alb_target_group_attachment._target_group).to receive(:remote_resource).and_return(target_group).at_least(:once)
+
+      remote_resource = alb_target_group_attachment.remote_resource_params
+
+      expect(remote_resource[:_terraform_id]).to eq("#{default_target_group_arn}/#{default_lambda_arn}")
+      expect(remote_resource[:_geo_id]).to eq("#{default_target_group_arn}:#{default_lambda_arn}")
+      expect(remote_resource[:target_group_arn]).to eq(default_target_group_arn)
+      expect(remote_resource[:target_id]).to eq(default_lambda_arn)
+    end
+  end
+end


### PR DESCRIPTION
This is a work in progress for adding support for ALB listeners with routing rules.

**Changes**

- Add resource for target group attachments
- Disable tag and name validation for listener rules
- Split validation for lambda and instance target groups

**TODO**

- [x] Confirm this is the correct way to implement
- [x] Add specs