### PR TITLE
Adds support for aws_pinpoint_app resource.

### DIFF
--- a/lib/geoengineer/resources/aws/pinpoint/aws_pinpoint_app.rb
+++ b/lib/geoengineer/resources/aws/pinpoint/aws_pinpoint_app.rb
@@ -1,0 +1,27 @@
+########################################################################
+# AwsPinpointApp is the +aws_pinpoint_app+ terrform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/pinpoint_app.html Terraform Docs}
+########################################################################
+class GeoEngineer::Resources::AwsPinpointApp < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { name } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.pinpoint(provider).get_apps['applications_response'].item.map(&:to_h).map do |app|
+      app.merge(
+        {
+          name: app[:name],
+          _terraform_id: app[:id],
+          _geo_id: app[:name]
+        }
+      )
+    end
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -262,4 +262,11 @@ class AwsClients
       Aws::Organizations::Client
     )
   end
+
+  def self.pinpoint(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::Pinpoint::Client
+    )
+  end
 end


### PR DESCRIPTION
This adds support for defining Pinpoint applications/projects (AWS uses
the names interchangibly, it seems). This was a request to work on
codifying some of the existing resources and move away from manually
configuring them.