### PR TITLE
[Fix] allow projects to be sub-folders, speed improvement on node dereference

### DIFF
--- a/lib/geoengineer/gps/finder.rb
+++ b/lib/geoengineer/gps/finder.rb
@@ -45,8 +45,19 @@ class GeoEngineer::GPS::Finder
   attr_reader :nodes, :constants
   attr_reader :project, :environment, :configuration, :node_type, :node_name
 
+  def self.build_nodes_lookup_hash(nodes_list)
+    nodes_id_hash = {}
+    nodes_list.each { |node| nodes_id_hash[node.node_id] = node }
+    nodes_id_hash
+  end
+
   def initialize(nodes, constants, context = {})
-    @nodes = nodes
+    @nodes = if nodes.is_a?(Array)
+               GeoEngineer::GPS::Finder.build_nodes_lookup_hash(nodes)
+             else
+               nodes
+             end
+
     @constants = constants
 
     # extract the context
@@ -126,7 +137,7 @@ class GeoEngineer::GPS::Finder
   end
 
   def search_node_components(components)
-    search_nodes(
+    serach_nodes_with_defaults(
       components["project"],
       components["environment"],
       components["configuration"],
@@ -135,13 +146,25 @@ class GeoEngineer::GPS::Finder
     )
   end
 
-  def search_nodes(project, environment, configuration, node_type, node_name)
+  def serach_nodes_with_defaults(project, environment, configuration, node_type, node_name)
     project = @project             if project.empty?
     environment = @environment     if environment.empty?
     configuration = @configuration if configuration.empty?
     node_type = @node_type         if node_type.empty?
     node_name = @node_name         if node_name.empty?
 
-    nodes.select { |n| n.match(project, environment, configuration, node_type, node_name) }
+    search_nodes(project, environment, configuration, node_type, node_name)
+  end
+
+  def search_nodes(project, environment, configuration, node_type, node_name)
+    node_id = [project, environment, configuration, node_type, node_name].compact.join(":")
+
+    if node_id.include?("*")
+      # TODO: allow lookup hash to also *
+      nodes.values.select { |n| n.match(project, environment, configuration, node_type, node_name) }
+    else
+      # if we have an exact query without * we can use a lookup hash
+      [nodes[node_id]].compact # must return list
+    end
   end
 end

--- a/lib/geoengineer/gps/finder.rb
+++ b/lib/geoengineer/gps/finder.rb
@@ -137,7 +137,7 @@ class GeoEngineer::GPS::Finder
   end
 
   def search_node_components(components)
-    serach_nodes_with_defaults(
+    search_nodes_with_defaults(
       components["project"],
       components["environment"],
       components["configuration"],
@@ -146,7 +146,7 @@ class GeoEngineer::GPS::Finder
     )
   end
 
-  def serach_nodes_with_defaults(project, environment, configuration, node_type, node_name)
+  def search_nodes_with_defaults(project, environment, configuration, node_type, node_name)
     project = @project             if project.empty?
     environment = @environment     if environment.empty?
     configuration = @configuration if configuration.empty?

--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -110,13 +110,15 @@ class GeoEngineer::GPS
     end
 
     # add pre-context
-    @_nodes.each { |node| node.set_values(@_nodes, @constants) }
+    nodes_hash = GeoEngineer::GPS::Finder.build_nodes_lookup_hash(@_nodes)
+    @_nodes.each { |node| node.set_values(nodes_hash, @constants) }
 
     @_nodes.each(&:validate) # validate all nodes
 
     @_nodes = expand_meta_nodes(@_nodes, @_nodes) # this validates as it expands
 
-    @_nodes.each { |node| node.set_values(@_nodes, @constants) }
+    nodes_hash = GeoEngineer::GPS::Finder.build_nodes_lookup_hash(@_nodes)
+    @_nodes.each { |node| node.set_values(nodes_hash, @constants) }
 
     @_nodes
   end
@@ -212,7 +214,10 @@ class GeoEngineer::GPS
   # This method takes the file name of the geoengineer project file
   # it calculates the location of the gps file
   def partial_of(file_name, &block)
-    org_name, project_name = file_name.gsub(".rb", "").split("/")[-2..-1]
+    projects_str, org_name, project_name = file_name.gsub(".rb", "").split("/", 3)
+
+    raise "projects must be in 'projects' folder" if projects_str != "projects"
+
     full_name = "#{org_name}/#{project_name}"
 
     @created_projects ||= {}


### PR DESCRIPTION
This allows projects to be multi-layered deep e.g.
`/projects/test/example/ruby/service.gps.yml` will have a project name of `example/ruby/service`

Also using a hash for node lookup saves a few seconds.