### PR TITLE
Memoize node_id

### DIFF
--- a/lib/geoengineer/gps/node.rb
+++ b/lib/geoengineer/gps/node.rb
@@ -121,7 +121,7 @@ class GeoEngineer::GPS::Node
   end
 
   def node_id
-    [project, environment, configuration, node_type, node_name].compact.join(":")
+    @node_id ||= [project, environment, configuration, node_type, node_name].compact.join(":")
   end
 
   def load_gps_file


### PR DESCRIPTION
Through profiling it turns out ~10% of `geo test` time is spent in
node_id - this memoization saves 4s on the 40s test execution time