### PR TITLE
Add support for the postgresql provider

### DIFF
--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -34,4 +34,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'octokit',           '~> 4.8'
   s.add_dependency 'json-schema',       '~> 2.8.1'
   s.add_dependency 'tty-pager',         '~> 0.12.0'
+  s.add_dependency 'pg',                '~> 0.18.4'
 end

--- a/lib/geoengineer.rb
+++ b/lib/geoengineer.rb
@@ -32,6 +32,7 @@ require 'octokit'
 require 'ostruct'
 require 'uri'
 require 'securerandom'
+require 'pg'
 
 Dir["#{File.dirname(__FILE__)}/geoengineer/utils/**/*.rb"].each { |f| require f }
 

--- a/lib/geoengineer/resources/postgresql/postgresql_database.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_database.rb
@@ -1,0 +1,25 @@
+################################################################################
+# PostgresqlDatabase is the postgresql_database+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/postgresql/r/postgresql_database.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
+  #validate -> { validate_required_attributes([:team_id, :repository]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{name}" } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    database_names = PostgresClient.database_names(provider)
+    databases = []
+    database_names.each do |row|
+      databases << { _terraform_id: row['datname']}
+    end
+
+    return databases
+  end
+end

--- a/lib/geoengineer/resources/postgresql/postgresql_database.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_database.rb
@@ -14,7 +14,7 @@ class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    database_names = PostgresClient.database_names(provider)
+    database_names = PostgresqlClient.database_names(provider)
     database_names.map { |name| { _terraform_id: name } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_database.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_database.rb
@@ -4,9 +4,10 @@
 # {https://www.terraform.io/docs/providers/postgresql/r/postgresql_database.html Terraform Docs}
 ################################################################################
 class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{name}" } }
+  after :initialize, -> { _geo_id -> { name.to_s } }
 
   def support_tags?
     false
@@ -14,6 +15,6 @@ class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     database_names = PostgresClient.database_names(provider)
-    database_names.map { |name| { _terraform_id: name }}
+    database_names.map { |name| { _terraform_id: name } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_extension.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_extension.rb
@@ -1,9 +1,9 @@
 ################################################################################
-# PostgresqlDatabase is the postgresql_database+ Terraform resource.
+# PostgresqlExtension is the postgresql_extension+ Terraform resource.
 #
-# {https://www.terraform.io/docs/providers/postgresql/r/postgresql_database.html Terraform Docs}
+# {https://www.terraform.io/docs/providers/postgresql/r/postgresql_extension.html Terraform Docs}
 ################################################################################
-class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
+class GeoEngineer::Resources::PostgresqlExtension < GeoEngineer::Resource
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{name}" } }
@@ -13,7 +13,7 @@ class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    database_names = PostgresClient.database_names(provider)
-    database_names.map { |name| { _terraform_id: name }}
+    database_extensions = PostgresClient.database_extensions(provider)
+    database_extensions.map { |extension| { _terraform_id: extension }}
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_extension.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_extension.rb
@@ -4,9 +4,10 @@
 # {https://www.terraform.io/docs/providers/postgresql/r/postgresql_extension.html Terraform Docs}
 ################################################################################
 class GeoEngineer::Resources::PostgresqlExtension < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{name}" } }
+  after :initialize, -> { _geo_id -> { name.to_s } }
 
   def support_tags?
     false
@@ -14,6 +15,6 @@ class GeoEngineer::Resources::PostgresqlExtension < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     database_extensions = PostgresClient.database_extensions(provider)
-    database_extensions.map { |extension| { _terraform_id: extension }}
+    database_extensions.map { |extension| { _terraform_id: extension } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_extension.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_extension.rb
@@ -14,7 +14,7 @@ class GeoEngineer::Resources::PostgresqlExtension < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    database_extensions = PostgresClient.database_extensions(provider)
+    database_extensions = PostgresqlClient.database_extensions(provider)
     database_extensions.map { |extension| { _terraform_id: extension } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_role.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_role.rb
@@ -1,9 +1,10 @@
 ################################################################################
-# PostgresqlDatabase is the postgresql_database+ Terraform resource.
+# PostgresqlRole is the postgresql_role+ Terraform resource.
 #
-# {https://www.terraform.io/docs/providers/postgresql/r/postgresql_database.html Terraform Docs}
+# {https://www.terraform.io/docs/providers/postgresql/r/postgresql_role.html Terraform Docs}
 ################################################################################
-class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
+class GeoEngineer::Resources::PostgresqlRole < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{name}" } }
@@ -13,7 +14,7 @@ class GeoEngineer::Resources::PostgresqlDatabase < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    database_names = PostgresClient.database_names(provider)
-    database_names.map { |name| { _terraform_id: name }}
+    database_roles = PostgresClient.database_roles(provider)
+    database_roles.map { |role| { _terraform_id: role }}
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_role.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_role.rb
@@ -7,7 +7,7 @@ class GeoEngineer::Resources::PostgresqlRole < GeoEngineer::Resource
   validate -> { validate_required_attributes([:name]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{name}" } }
+  after :initialize, -> { _geo_id -> { name.to_s } }
 
   def support_tags?
     false
@@ -15,6 +15,6 @@ class GeoEngineer::Resources::PostgresqlRole < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     database_roles = PostgresClient.database_roles(provider)
-    database_roles.map { |role| { _terraform_id: role }}
+    database_roles.map { |role| { _terraform_id: role } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_role.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_role.rb
@@ -14,7 +14,7 @@ class GeoEngineer::Resources::PostgresqlRole < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    database_roles = PostgresClient.database_roles(provider)
+    database_roles = PostgresqlClient.database_roles(provider)
     database_roles.map { |role| { _terraform_id: role } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_schema.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_schema.rb
@@ -1,0 +1,20 @@
+################################################################################
+# PostgresqlRole is the postgresql_schema+ Terraform resource.
+#
+# {https://www.terraform.io/docs/providers/postgresql/r/postgresql_schema.html Terraform Docs}
+################################################################################
+class GeoEngineer::Resources::PostgresqlSchema < GeoEngineer::Resource
+  validate -> { validate_required_attributes([:name]) }
+
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { "#{name}" } }
+
+  def support_tags?
+    false
+  end
+
+  def self._fetch_remote_resources(provider)
+    database_schemas = PostgresClient.database_schemas(provider)
+    database_schemas.map { |schema| { _terraform_id: schema }}
+  end
+end

--- a/lib/geoengineer/resources/postgresql/postgresql_schema.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_schema.rb
@@ -1,5 +1,5 @@
 ################################################################################
-# PostgresqlRole is the postgresql_schema+ Terraform resource.
+# PostgresqlSchema is the postgresql_schema+ Terraform resource.
 #
 # {https://www.terraform.io/docs/providers/postgresql/r/postgresql_schema.html Terraform Docs}
 ################################################################################
@@ -7,7 +7,7 @@ class GeoEngineer::Resources::PostgresqlSchema < GeoEngineer::Resource
   validate -> { validate_required_attributes([:name]) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{name}" } }
+  after :initialize, -> { _geo_id -> { name.to_s } }
 
   def support_tags?
     false
@@ -15,6 +15,6 @@ class GeoEngineer::Resources::PostgresqlSchema < GeoEngineer::Resource
 
   def self._fetch_remote_resources(provider)
     database_schemas = PostgresClient.database_schemas(provider)
-    database_schemas.map { |schema| { _terraform_id: schema }}
+    database_schemas.map { |schema| { _terraform_id: schema } }
   end
 end

--- a/lib/geoengineer/resources/postgresql/postgresql_schema.rb
+++ b/lib/geoengineer/resources/postgresql/postgresql_schema.rb
@@ -14,7 +14,7 @@ class GeoEngineer::Resources::PostgresqlSchema < GeoEngineer::Resource
   end
 
   def self._fetch_remote_resources(provider)
-    database_schemas = PostgresClient.database_schemas(provider)
+    database_schemas = PostgresqlClient.database_schemas(provider)
     database_schemas.map { |schema| { _terraform_id: schema } }
   end
 end

--- a/lib/geoengineer/utils/postgres_client.rb
+++ b/lib/geoengineer/utils/postgres_client.rb
@@ -1,0 +1,17 @@
+########################################################################
+# GithubClient exposes a set of API calls to fetch data from GitHub.
+# The primary reason for centralizing them here is testing and stubbing.
+########################################################################
+class PostgresClient
+  def self.database_setup(provider)
+    PG.connect( host: provider.host, port: provider.port, dbname: provider.database, user: provider.username, 
+                password: provider.password )
+  end
+
+  def self.database_names(provider)
+    conn = self.database_setup(provider)
+    rows = conn.exec( "SELECT datname FROM pg_database")
+    return rows
+  end
+
+end

--- a/lib/geoengineer/utils/postgres_client.rb
+++ b/lib/geoengineer/utils/postgres_client.rb
@@ -10,8 +10,26 @@ class PostgresClient
 
   def self.database_names(provider)
     conn = self.database_setup(provider)
-    rows = conn.exec( "SELECT datname FROM pg_database")
-    return rows
+    rows = conn.exec("SELECT datname FROM pg_database")
+    return rows.column_values(0)
+  end
+
+  def self.database_roles(provider)
+    conn = self.database_setup(provider)
+    rows = conn.exec("SELECT rolname FROM pg_roles")
+    return rows.column_values(0)
+  end
+
+  def self.database_schemas(provider)
+    conn = self.database_setup(provider)
+    rows = conn.exec("SELECT schema_name FROM information_schema.schemata")
+    return rows.column_values(0)
+  end
+
+  def self.database_extensions(provider)
+    conn = self.database_setup(provider)
+    rows = conn.exec("SELECT extname FROM pg_extension")
+    return rows.column_values(0)
   end
 
 end

--- a/lib/geoengineer/utils/postgres_client.rb
+++ b/lib/geoengineer/utils/postgres_client.rb
@@ -1,35 +1,34 @@
 ########################################################################
-# GithubClient exposes a set of API calls to fetch data from GitHub.
+# PostgresClient exposes a set of API calls to fetch data from Postgres.
 # The primary reason for centralizing them here is testing and stubbing.
 ########################################################################
 class PostgresClient
   def self.database_setup(provider)
-    PG.connect( host: provider.host, port: provider.port, dbname: provider.database, user: provider.username, 
-                password: provider.password )
+    PG.connect({ host: provider.host, port: provider.port, dbname: provider.database, user: provider.username,
+                 password: provider.password })
   end
 
   def self.database_names(provider)
     conn = self.database_setup(provider)
     rows = conn.exec("SELECT datname FROM pg_database")
-    return rows.column_values(0)
+    rows.column_values(0)
   end
 
   def self.database_roles(provider)
     conn = self.database_setup(provider)
     rows = conn.exec("SELECT rolname FROM pg_roles")
-    return rows.column_values(0)
+    rows.column_values(0)
   end
 
   def self.database_schemas(provider)
     conn = self.database_setup(provider)
     rows = conn.exec("SELECT schema_name FROM information_schema.schemata")
-    return rows.column_values(0)
+    rows.column_values(0)
   end
 
   def self.database_extensions(provider)
     conn = self.database_setup(provider)
     rows = conn.exec("SELECT extname FROM pg_extension")
-    return rows.column_values(0)
+    rows.column_values(0)
   end
-
 end

--- a/lib/geoengineer/utils/postgresql_client.rb
+++ b/lib/geoengineer/utils/postgresql_client.rb
@@ -1,8 +1,8 @@
 ########################################################################
-# PostgresClient exposes a set of API calls to fetch data from Postgres.
+# PostgresqlClient exposes a set of API calls to fetch data from Postgresql.
 # The primary reason for centralizing them here is testing and stubbing.
 ########################################################################
-class PostgresClient
+class PostgresqlClient
   def self.database_setup(provider)
     PG.connect({ host: provider.host, port: provider.port, dbname: provider.database, user: provider.username,
                  password: provider.password })

--- a/spec/resources/postgresql_database.rb
+++ b/spec/resources/postgresql_database.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::PostgresqlDatabase) do
+  let(:postgres_results) { ['testdb', 'testdb2', 'template0'] }
+
+  before do
+    allow(PostgresqlClient).to receive(:database_names).and_return({})
+  end
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      allow(PostgresqlClient).to receive(:database_names).and_return(postgres_results)
+    end
+
+    it 'should create list of hashes from returned postgres' do
+      remote_resources = GeoEngineer::Resources::PostgresqlDatabase._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 3
+    end
+  end
+end

--- a/spec/resources/postgresql_extension.rb
+++ b/spec/resources/postgresql_extension.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::PostgresqlExtension) do
+  let(:postgres_results) { ['plpgsql', 'postgis', 'testext'] }
+
+  before do
+    allow(PostgresqlClient).to receive(:database_extensions).and_return({})
+  end
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      allow(PostgresqlClient).to receive(:database_extensions).and_return(postgres_results)
+    end
+
+    it 'should create list of hashes from returned postgres' do
+      remote_resources = GeoEngineer::Resources::PostgresqlExtension._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 3
+    end
+  end
+end

--- a/spec/resources/postgresql_role.rb
+++ b/spec/resources/postgresql_role.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::PostgresqlRole) do
+  let(:postgres_results) { ['rds_superuser', 'rdsadmin', 'test_role'] }
+
+  before do
+    allow(PostgresqlClient).to receive(:database_roles).and_return({})
+  end
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      allow(PostgresqlClient).to receive(:database_roles).and_return(postgres_results)
+    end
+
+    it 'should create list of hashes from returned postgres' do
+      remote_resources = GeoEngineer::Resources::PostgresqlRole._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 3
+    end
+  end
+end

--- a/spec/resources/postgresql_schema.rb
+++ b/spec/resources/postgresql_schema.rb
@@ -1,0 +1,22 @@
+require_relative '../spec_helper'
+
+describe(GeoEngineer::Resources::PostgresqlSchema) do
+  let(:postgres_results) { ['pg_catalog', 'public', 'test_schema'] }
+
+  before do
+    allow(PostgresqlClient).to receive(:database_schemas).and_return({})
+  end
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe "#_fetch_remote_resources" do
+    before do
+      allow(PostgresqlClient).to receive(:database_schemas).and_return(postgres_results)
+    end
+
+    it 'should create list of hashes from returned postgres' do
+      remote_resources = GeoEngineer::Resources::PostgresqlSchema._fetch_remote_resources(nil)
+      expect(remote_resources.length).to eq 3
+    end
+  end
+end


### PR DESCRIPTION
This PR adds support for configuring postgresql databases, extensions, roles, and schemas through geoengineer via the [postgresql provider](https://www.terraform.io/docs/providers/postgresql/index.html).