### PR TITLE
Bug fixes for aws_msk_cluster and aws_msk_configuration

### DIFF
--- a/lib/geoengineer/resource.rb
+++ b/lib/geoengineer/resource.rb
@@ -239,7 +239,7 @@ class GeoEngineer::Resource
 
   def self._deep_symbolize_keys(obj)
     case obj
-    when Hash then
+    when Hash
       obj.each_with_object({}) do |(key, value), hash|
         hash[key.to_sym] = _deep_symbolize_keys(value)
       end

--- a/lib/geoengineer/resources/aws/msk/aws_msk_cluster.rb
+++ b/lib/geoengineer/resources/aws/msk/aws_msk_cluster.rb
@@ -6,6 +6,7 @@
 class GeoEngineer::Resources::AwsMskCluster < GeoEngineer::Resource
   validate -> { validate_required_attributes([:cluster_name, :kafka_version, :number_of_broker_nodes]) }
   validate -> { validate_required_subresource(:broker_node_group_info) }
+  validate -> { validate_required_subresource(:encryption_info) }
   validate -> {
              validate_subresource_required_attributes(:broker_node_group_info,
                                                       [:client_subnets,
@@ -14,14 +15,40 @@ class GeoEngineer::Resources::AwsMskCluster < GeoEngineer::Resource
                                                        :security_groups])
            }
   validate -> { validate_subresource_required_attributes(:configuration_info, [:arn, :revision]) }
+  validate -> { validate_subresource_required_attributes(:encryption_info, [:encryption_in_transit]) }
+  validate -> { validate_subresource_required_attributes(:encryption_in_transit, [:client_broker]) }
+  validate :validate_encryption_in_transit_protocol
+  validate :validate_cluster_name
+  validate :validate_ebs_volume_size
 
-  after :initialize, -> { _terraform_id -> { self[:cluster_name] } }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { self[:cluster_name] } }
+
+  def validate_encryption_in_transit_protocol
+    return nil unless encryption_info # needed for specs
+    valid_values = ["TLS", "TLS_PLAINTEXT", "PLAINTEXT"]
+    proto = encryption_info.encryption_in_transit.client_broker
+    return "Error: #{proto} is invalid encryption protocol" unless valid_values.include?(proto)
+  end
+
+  def validate_cluster_name
+    return nil unless cluster_name # needed for specs
+    return "Error: #{cluster_name} is invalid cluster name" if cluster_name.match(/^[a-zA-Z0-9-]+$/).nil? ||
+                                                               cluster_name.length > 64
+  end
+
+  def validate_ebs_volume_size
+    return nil unless broker_node_group_info # needed for specs
+    vol_size = broker_node_group_info.ebs_volume_size
+    return "Error: invalid EBS volume size of #{vol_size} GiB" if vol_size > 16_384 ||
+                                                                  vol_size < 1
+  end
 
   def self._fetch_remote_resources(provider)
     AwsClients.kafka(provider).list_clusters['cluster_info_list'].map { |msk_cluster|
       {
         name: msk_cluster[:cluster_name],
-        _terraform_id: msk_cluster[:cluster_name],
+        _terraform_id: msk_cluster[:cluster_arn],
         _geo_id: msk_cluster[:cluster_name]
       }
     }

--- a/lib/geoengineer/resources/aws/msk/aws_msk_configuration.rb
+++ b/lib/geoengineer/resources/aws/msk/aws_msk_configuration.rb
@@ -6,13 +6,18 @@
 class GeoEngineer::Resources::AwsMskConfiguration < GeoEngineer::Resource
   validate -> { validate_required_attributes([:server_properties, :kafka_versions, :name]) }
 
-  after :initialize, -> { _terraform_id -> { self[:name] } }
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+  after :initialize, -> { _geo_id -> { self[:name] } }
+
+  def support_tags?
+    false
+  end
 
   def self._fetch_remote_resources(provider)
     AwsClients.kafka(provider).list_configurations['configurations'].map { |msk_config|
       {
         name: msk_config[:name],
-        _terraform_id: msk_config[:name],
+        _terraform_id: msk_config[:arn],
         _geo_id: msk_config[:name]
       }
     }

--- a/spec/resources/aws_msk_cluster_spec.rb
+++ b/spec/resources/aws_msk_cluster_spec.rb
@@ -14,10 +14,12 @@ describe GeoEngineer::Resources::AwsMskCluster do
         {
           cluster_info_list: [
             {
-              cluster_name: "msk_name1"
+              cluster_name: "msk_name1",
+              cluster_arn: "arn:aws:iam::123456789012:user/FakeUser1"
             },
             {
-              cluster_name: "msk_name2"
+              cluster_name: "msk_name2",
+              cluster_arn: "arn:aws:iam::123456789012:user/FakeUser2"
             }
           ]
         }
@@ -29,8 +31,8 @@ describe GeoEngineer::Resources::AwsMskCluster do
       expect(resources.count).to eql 2
 
       test_msk_cluster = resources.first
-      expect(test_msk_cluster[:_terraform_id]).to eql "msk_name1"
       expect(test_msk_cluster[:_geo_id]).to eql "msk_name1"
+      expect(test_msk_cluster[:_terraform_id]).to eql "arn:aws:iam::123456789012:user/FakeUser1"
     end
   end
 end

--- a/spec/resources/aws_msk_configuration_spec.rb
+++ b/spec/resources/aws_msk_configuration_spec.rb
@@ -15,7 +15,7 @@ describe GeoEngineer::Resources::AwsMskConfiguration do
           configurations: [
             {
               name: "msk_config_name1",
-              arn: "arn:aws:iam::123456789012:user/FakeUser",
+              arn: "arn:aws:iam::123456789012:user/FakeUser1",
               description: "This is msk_config_name1",
               creation_time: Time.parse("2019-07-16 17:33:11 utc"),
               kafka_versions: [
@@ -31,7 +31,7 @@ describe GeoEngineer::Resources::AwsMskConfiguration do
             },
             {
               name: "msk_config_name2",
-              arn: "arn:aws:iam::123456789012:user/FakeUser",
+              arn: "arn:aws:iam::123456789012:user/FakeUser2",
               description: "This is msk_config_name2",
               creation_time: Time.parse("2019-07-16 17:33:11 utc"),
               kafka_versions: [
@@ -55,7 +55,7 @@ describe GeoEngineer::Resources::AwsMskConfiguration do
       expect(resources.count).to eql 2
 
       test_msk_config = resources.first
-      expect(test_msk_config[:_terraform_id]).to eql "msk_config_name1"
+      expect(test_msk_config[:_terraform_id]).to eql "arn:aws:iam::123456789012:user/FakeUser1"
       expect(test_msk_config[:_geo_id]).to eql "msk_config_name1"
     end
   end


### PR DESCRIPTION
# Background
The way `_terraform_id` was initialized previously caused failures on `./geo plan` and `./geo apply`.

# Changes

* Changed how `_terraform_id` is set to fix plan failures. I.e. `_terraform_id: msk_config[:arn]`.

* Changed tests to reflect the above fix.

* Added more validation for `aws_msk_cluster` attributes based on what AWS requires when creating an MSK cluster through a console.


* Optional (in Terraform) `encryption_info.encryption_in_transit.client_broker` is now required because of inconsistency between Terraform and AWS SDK defaults for this attribute. This is done to remove ambiguity.

# Testing
Both `aws_msk_cluster` and `aws_msk_configuration` were manually tested in dev environment with `./geo plan` and `./geo apply`.

