### PR TITLE
Use major version when expressing a dependency on aws-sdk

### DIFF
--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "pry-byebug", '~> 3.4'
 
   s.add_dependency 'netaddr',           '~> 1.5'
-  s.add_dependency 'aws-sdk',           '~> 3.0'
+  s.add_dependency 'aws-sdk',           '~> 3'
   s.add_dependency 'commander',         '~> 4.4'
   s.add_dependency 'colorize',          '~> 0.7'
   s.add_dependency 'parallel',          '~> 1.10'


### PR DESCRIPTION
# Background

The current`aws-sdk` version is missing `list_configurations` method in `Aws::Kafka::Client` class. This method is used in [aws_msk_configuration](https://github.com/coinbase/geoengineer/blob/master/lib/geoengineer/resources/aws/msk/aws_msk_configuration.rb) in `_fetch_remote_resources`.

# Changes

Geoengineer now uses major version of `aws-sdk`, just like [aws-sdk-ruby](https://github.com/aws/aws-sdk-ruby) docs suggest.

# Testing

`bundle exec rspec` passes all tests.