### PR TITLE
remove require as it is a circular dependency to this gem

### DIFF
--- a/lib/geoengineer/templates/users_with_policies.rb
+++ b/lib/geoengineer/templates/users_with_policies.rb
@@ -1,5 +1,3 @@
-require 'geoengineer'
-
 # Role Template
 class GeoEngineer::Templates::UsersWithPolicies < GeoEngineer::Template
   attr_reader :users, :policies


### PR DESCRIPTION
Running geo from bin/geo causes this issue. After removing the require it works.

```
➜  bin  git:(master) ✗ ./geo help
Traceback (most recent call last):
    9: from ./geo:3:in `<main>'
    8: from ./geo:3:in `require_relative'
    7: from /Users/aartiparikh/github.com/aarti/geoengineer/lib/geoengineer.rb:45:in `<top (required)>'
    6: from /Users/aartiparikh/github.com/aarti/geoengineer/lib/geoengineer.rb:45:in `each'
    5: from /Users/aartiparikh/github.com/aarti/geoengineer/lib/geoengineer.rb:45:in `block in <top (required)>'
    4: from /Users/aartiparikh/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
    3: from /Users/aartiparikh/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
    2: from /Users/aartiparikh/github.com/aarti/geoengineer/lib/geoengineer/templates/users_with_policies.rb:1:in `<top (required)>'
    1: from /Users/aartiparikh/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Users/aartiparikh/.rbenv/versions/2.5.5/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- geoengineer (LoadError)
```