### PR TITLE
[chore] rename default GEO_ENV -> development

### DIFF
--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -89,7 +89,7 @@ class GeoCLI
   end
 
   def require_environment(options = nil)
-    @env_name = options&.environment || ENV['GEO_ENV'] || 'staging'
+    @env_name = options&.environment || ENV['GEO_ENV'] || 'development'
     puts "Using environment '#{@env_name}'\n" if @verbose
     begin
       require_from_pwd "environments/#{@env_name}"


### PR DESCRIPTION
Some users are getting issues when not using AWS (bundle exec geo test) and GEO_ENV is not set, so it defaults to staging. But we use development, not staging - therefore, their CLI breaks.

This will improve their productivity by defaulting to the right environment without needing them to configure it.