### PR TITLE
Update aws_db_instance to initialize allow_major_version_upgrade

### DIFF
--- a/lib/geoengineer/resources/aws/db/aws_db_instance.rb
+++ b/lib/geoengineer/resources/aws/db/aws_db_instance.rb
@@ -30,7 +30,8 @@ class GeoEngineer::Resources::AwsDbInstance < GeoEngineer::Resource
     tfstate[:primary][:attributes] = {
       'identifier' => _terraform_id,
       'final_snapshot_identifier' => final_snapshot_identifier,
-      'skip_final_snapshot' => 'true'
+      'skip_final_snapshot' => 'true',
+      'allow_major_version_upgrade' => 'false'
     }
     tfstate
   end


### PR DESCRIPTION
From looking over the AWS documentation, AllowMajorVersionUpgrade is a field on
the ModifyDBInstance action, however it is not a field on DBInstance, which is
returned with DescribeDBInstances. The field isn't persisted at all, and is
simply used as a necessary check when also updating the EngineVersion.

From the documentation, the field needs to be set to true when also changing
EngineVersion.

In Geoengineer, the field always shows up in plans as `"" => "false"`. This is
becaues it is always initialized to an empty string in Terraform, and not set to
a specific value at all on refresh.

This updates Geoengineer to populate it with `false` in `to_terraform_state` so
it begins with a blank/default value in Terraform.