### PR TITLE
Add the ACMPCA resource to geoengineer

### DIFF
--- a/lib/geoengineer/resources/aws/certificate_manager/aws_acmpca_certificate_authority.rb
+++ b/lib/geoengineer/resources/aws/certificate_manager/aws_acmpca_certificate_authority.rb
@@ -1,0 +1,40 @@
+########################################################################
+# AwsAcmpcaCertificateAuthority is the +aws_acmpca_certificate_authority+
+# terraform resource,
+#
+# {https://www.terraform.io/docs/providers/aws/r/acmpca_certificate_authority.html}
+########################################################################
+class GeoEngineer::Resources::AwsAcmpcaCertificateAuthority < GeoEngineer::Resource
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+
+  validate -> { validate_required_attributes([:type]) }
+  validate -> { validate_required_attributes([:tags]) }
+  validate -> { validate_required_attributes([:certificate_authority_configuration]) }
+  validate -> { validate_subresource_required_attributes(:certificate_authority_configuration, [:subject]) }
+  validate -> { validate_subresource_required_attributes(:certificate_authority_configuration, [:key_algorithm]) }
+  validate -> { validate_subresource_required_attributes(:certificate_authority_configuration, [:signing_algorithm]) }
+  validate -> { validate_subresource_required_attributes(:subject, [:common_name]) }
+
+  after :initialize, -> { _geo_id -> { [type, common_name].join("::") } }
+  def common_name
+    if !self.certificate_authority_configuration.nil? &&
+       !self.certificate_authority_configuration.subject.nil? &&
+       !self.certificate_authority_configuration.subject.common_name.nil?
+
+      return self.certificate_authority_configuration.subject.common_name
+    end
+    NullObject.new()
+  end
+
+  def self._fetch_remote_resources(provider)
+    AwsClients.acmpca(provider)
+              .list_certificate_authorities["certificate_authorities"]
+              .map(&:to_h)
+              .reject { |ca| ca[:status] == "DELETED" }
+              .map { |ca|
+      ca[:_terraform_id] = ca[:arn]
+      ca[:_geo_id] = "#{ca[:type]}::#{ca[:certificate_authority_configuration][:subject][:common_name]}"
+      ca
+    }
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -283,4 +283,11 @@ class AwsClients
       Aws::Pinpoint::Client
     )
   end
+
+  def self.acmpca(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::ACMPCA::Client
+    )
+  end
 end

--- a/spec/resources/aws_acmpca_spec.rb
+++ b/spec/resources/aws_acmpca_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAcmpcaCertificateAuthority do
+  let(:aws_client) { AwsClients.acmpca }
+
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  before { aws_client.setup_stubbing }
+
+  describe '#initialize' do
+    it 'should create an acmpca resource with correct geo id' do
+      resources = GeoEngineer::Resources::AwsAcmpcaCertificateAuthority.new(
+        "aws_acmpca_certificate_authority",
+        "abcbhq_dot_net"
+      ) {
+        type "ROOT"
+        certificate_authority_configuration {
+          subject {
+            common_name "abcbhq.net"
+          }
+        }
+      }
+      expect(resources[:_geo_id]).to eql "ROOT::abcbhq.net"
+    end
+  end
+
+  describe '#_fetch_remote_resources' do
+    before do
+      aws_client.stub_responses(
+        :list_certificate_authorities,
+        {
+          certificate_authorities: [
+            {
+              arn: "arn:aws:iam::123456789012:user/FakeUser1",
+              type: "ROOT",
+              certificate_authority_configuration:
+                {
+                  key_algorithm: "RSA_4096",
+                  signing_algorithm: "SHA512WITHRSA",
+                  subject: {
+                    common_name: "example1.com"
+                  }
+                }
+            },
+            {
+              arn: "arn:aws:iam::123456789012:user/FakeUser2",
+              type: "SUBORDINATE",
+              certificate_authority_configuration:
+                {
+                  key_algorithm: "RSA_4096",
+                  signing_algorithm: "SHA512WITHRSA",
+                  subject: {
+                    common_name: "example1.com"
+                  }
+                }
+            }
+          ]
+        }
+      )
+    end
+
+    it 'should create an array of hashes from the AWS response' do
+      resources = GeoEngineer::Resources::AwsAcmpcaCertificateAuthority._fetch_remote_resources(nil)
+      expect(resources.count).to eql 2
+
+      test_acmpca = resources.first
+      expect(test_acmpca[:_geo_id]).to eql "ROOT::example1.com"
+      expect(test_acmpca[:_terraform_id]).to eql "arn:aws:iam::123456789012:user/FakeUser1"
+      expect(test_acmpca[:certificate_authority_configuration][:key_algorithm]).to eql "RSA_4096"
+      expect(test_acmpca[:certificate_authority_configuration][:signing_algorithm]).to eql "SHA512WITHRSA"
+      expect(test_acmpca[:certificate_authority_configuration][:subject][:common_name]).to eql "example1.com"
+    end
+  end
+end


### PR DESCRIPTION
This adds the ACMPCA resource to geoengineer. 
- The geo_id is a combination of the Type::Common_name.
- The ACMPCA resource does not include an easy to use name or identifiable/unique attribute that could have been used to create the geo_id so it had to be a combination.
- AWS keeps the deleted ACMPCA's around for 30 days and therefore they have been filtered out when fetching remote_resources.
- Tags were also considered for geo_id and could not be used since they are not returned during ListCertificateAuthorities call in AWS. AWS is moving away from making tags available in the same call and a seperate call for each resource called ListTags would have to be called if tags were to be used.
- An initialize resource test was added to verify that the geo_id is created correctly. 
- The nil checks in the common_name method were needed because the resources are created on the fly with metaprogramming and the common_resources_tests fail the after_initialize call if the nil checks are missing. 