### PR TITLE
change min ruby requirement to 2.5 and use optional safe

### DIFF
--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir.glob('spec/**/*.rb')
   s.executables << 'geo'
 
-  s.required_ruby_version = '>= 2.2.5'
+  s.required_ruby_version = '>= 2.5'
   s.add_development_dependency "rspec", '~> 3.4'
   s.add_development_dependency "rake", '~> 10.4'
   s.add_development_dependency "yard", '~> 0.9'

--- a/lib/geoengineer/resources/aws/certificate_manager/aws_acmpca_certificate_authority.rb
+++ b/lib/geoengineer/resources/aws/certificate_manager/aws_acmpca_certificate_authority.rb
@@ -17,13 +17,7 @@ class GeoEngineer::Resources::AwsAcmpcaCertificateAuthority < GeoEngineer::Resou
 
   after :initialize, -> { _geo_id -> { [type, common_name].join("::") } }
   def common_name
-    if !self.certificate_authority_configuration.nil? &&
-       !self.certificate_authority_configuration.subject.nil? &&
-       !self.certificate_authority_configuration.subject.common_name.nil?
-
-      return self.certificate_authority_configuration.subject.common_name
-    end
-    NullObject.new()
+    certificate_authority_configuration&.subject&.common_name || NullObject.new
   end
 
   def self._fetch_remote_resources(provider)


### PR DESCRIPTION
Given Ruby 2.3 reached end of life in March 2019 (https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/), changing the minimum required Ruby version to 2.5 so we could use the safe navigation operator (&.).