### PR TITLE
The ACM certificate resource for private CA issued certificates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ Gemfile.lock
 
 # IDEA
 .idea
+Makefile
+.vscode

--- a/examples/example_acmpca.rb
+++ b/examples/example_acmpca.rb
@@ -1,0 +1,30 @@
+## Run this from the root directory of geo.
+##
+##  ./bin/geo plan examples/example_acmpca.rb
+##
+GeoCLI.instance.env_name = "geoexperiments"
+GeoCLI.instance.environment = GeoEngineer::Environment.new("geoexperiments")
+project = GeoCLI.instance.environment.project("org","geoexperiments"){
+    environments "geoexperiments"
+}
+
+
+acmpca = project.resource("aws_acmpca_certificate_authority", "acbhq_dot_net") {
+    certificate_authority_configuration {
+       key_algorithm      "RSA_4096"
+       signing_algorithm "SHA512WITHRSA"
+
+       subject {
+         common_name  "acbhq.net"
+         country "US"
+         state "California"
+         organization "ABCCompany"
+       }
+     }
+    type "ROOT"
+    tags {
+      name "acbhq.net"
+    }
+  }
+
+p acmpca

--- a/examples/example_acmpca_certificate.rb
+++ b/examples/example_acmpca_certificate.rb
@@ -1,0 +1,24 @@
+## Run this from the root directory of geo.
+##
+##  ./bin/geo plan examples/example_acmpca_certificate.rb
+##
+GeoCLI.instance.env_name = "geoexperiments"
+GeoCLI.instance.environment = GeoEngineer::Environment.new("geoexperiments")
+project = GeoCLI.instance.environment.project("org","geoexperiments"){
+    environments "geoexperiments"
+}
+
+cert = project.resource("aws_acmpca_certificate_private_ca", "acbhq_dot_net") {
+    tags {
+        Name "acbhq.net"
+    }
+    domain_name "example.com"
+    validation_method "DNS"
+    subject_alternative_names ["DomainNameString"]
+    certificate_authority_arn "arn:aws:acmpca::123456789012:MyTestCA" #Not a real arn
+    options {
+        certificate_transparency_logging_preference false
+    }
+}
+
+p cert

--- a/lib/geoengineer/resources/aws/certificate_manager/aws_acm_certificate_private_ca.rb
+++ b/lib/geoengineer/resources/aws/certificate_manager/aws_acm_certificate_private_ca.rb
@@ -38,7 +38,7 @@ class GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa < GeoEngineer::Resou
                   cert[:_geo_id] = tag.value if tag.key == "Name"
                 }
               }
- end
+  end
 
   def support_tags?
     true

--- a/lib/geoengineer/resources/aws/certificate_manager/aws_acm_certificate_private_ca.rb
+++ b/lib/geoengineer/resources/aws/certificate_manager/aws_acm_certificate_private_ca.rb
@@ -1,0 +1,38 @@
+########################################################################
+# AwsAcmpcaCertificate resource issued by AWS Private CA
+#
+# Creating a private CA issued certificate
+# domain_name - (Required) A domain name for which the certificate should be issued
+# certificate_authority_arn - (Required) ARN of an ACMPCA
+# subject_alternative_names - (Optional) A list of domains that should be SANs in the issued certificate
+#
+# {https://www.terraform.io/docs/providers/aws/r/acmpca_certificate_authority.html}
+########################################################################
+class GeoEngineer::Resources::AwsAcmCertificatePrivateCa < GeoEngineer::Resource
+  after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
+
+  validate -> { validate_required_attributes([:domain_name]) }
+  validate -> { validate_required_attributes([:certificate_authority_arn]) }
+  validate -> { validate_required_attributes([:options]) }
+  validate -> { validate_subresource_required_attributes(:options, [:certificate_transparency_logging_preference]) }
+  validate -> { validate_has_tag(:Name) }
+  validate -> { validate_ctlp_disabled }
+
+  after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
+
+  def validate_ctlp_disabled
+    !options&.certificate_transparency_logging_preference
+  end
+
+  # The ACM certificate resource  does not wait for a certificate to be issued.
+  # Always create a new Certificate for now, no need to fetch exisiting resources
+  # The resource will be used in conjunction with aws_acm_certificate_validation resource
+  # at which point we need to fetch_remote_resources
+  def self._fetch_remote_resources(provider)
+    []
+  end
+
+  def support_tags?
+    true
+  end
+end

--- a/lib/geoengineer/utils/aws_clients.rb
+++ b/lib/geoengineer/utils/aws_clients.rb
@@ -290,4 +290,11 @@ class AwsClients
       Aws::ACMPCA::Client
     )
   end
+
+  def self.acm(provider = nil)
+    self.client_cache(
+      provider,
+      Aws::ACM::Client
+    )
+  end
 end

--- a/spec/resources/aws_acm_certificate_private_ca_spec.rb
+++ b/spec/resources/aws_acm_certificate_private_ca_spec.rb
@@ -1,11 +1,13 @@
 require_relative '../spec_helper'
 
-describe GeoEngineer::Resources::AwsAcmCertificatePrivateCa do
+describe GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa do
+  let(:aws_client) { AwsClients.acm }
+
   common_resource_tests(described_class, described_class.type_from_class_name)
 
   describe '#initialize' do
     it 'creates an acm certificate with correct geo id' do
-      resources = GeoEngineer::Resources::AwsAcmCertificatePrivateCa.new(
+      resources = GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa.new(
         "aws_acmpca_certificate_private_ca",
         "abcbhq_dot_net"
       ) {
@@ -21,6 +23,48 @@ describe GeoEngineer::Resources::AwsAcmCertificatePrivateCa do
       }
       expect(resources[:_geo_id]).to eql "test"
       expect(resources[:options][:certificate_transparency_logging_preference]).to eql false
+    end
+  end
+
+  describe '#_fetch_remote_resources' do
+    before do
+      aws_client.stub_responses(
+        :list_certificates,
+        {
+          certificate_summary_list: [
+            {
+              certificate_arn: "arn:aws:iam::certificate-authority/FakeCert1",
+              domain_name: "example1.com"
+            # },
+            # {
+            #   certificate_arn: "arn:aws:iam::123456789012:user/FakeUser2",
+            #   domain_name: "example2.com"
+            }
+          ]
+        }
+      )
+      aws_client.stub_responses(
+        :list_tags_for_certificate,
+        {
+          tags:[
+            {
+              key: "Name",
+              value: "mycerttag1"
+            }
+          ]
+        }
+      )
+
+    end
+
+    it 'should create an array of hashes from the AWS response' do
+      resources = GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa._fetch_remote_resources(nil)
+      expect(resources.count).to eql 1
+
+      test_acmpca = resources.first
+      expect(test_acmpca[:_geo_id]).to eql "mycerttag1"
+      expect(test_acmpca[:_terraform_id]).to eql "arn:aws:iam::certificate-authority/FakeCert1"
+      expect(test_acmpca[:certificate_arn]).to eql "arn:aws:iam::certificate-authority/FakeCert1"
     end
   end
 end

--- a/spec/resources/aws_acm_certificate_private_ca_spec.rb
+++ b/spec/resources/aws_acm_certificate_private_ca_spec.rb
@@ -1,0 +1,26 @@
+require_relative '../spec_helper'
+
+describe GeoEngineer::Resources::AwsAcmCertificatePrivateCa do
+  common_resource_tests(described_class, described_class.type_from_class_name)
+
+  describe '#initialize' do
+    it 'creates an acm certificate with correct geo id' do
+      resources = GeoEngineer::Resources::AwsAcmCertificatePrivateCa.new(
+        "aws_acmpca_certificate_private_ca",
+        "abcbhq_dot_net"
+      ) {
+        domain_name "example.com"
+        validation_method "DNS"
+        subject_alternative_names ["DomainNameString"]
+        tags {
+          Name "test"
+        }
+        options {
+          certificate_transparency_logging_preference false
+        }
+      }
+      expect(resources[:_geo_id]).to eql "test"
+      expect(resources[:options][:certificate_transparency_logging_preference]).to eql false
+    end
+  end
+end

--- a/spec/resources/aws_acm_certificate_private_ca_spec.rb
+++ b/spec/resources/aws_acm_certificate_private_ca_spec.rb
@@ -35,10 +35,6 @@ describe GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa do
             {
               certificate_arn: "arn:aws:iam::certificate-authority/FakeCert1",
               domain_name: "example1.com"
-            # },
-            # {
-            #   certificate_arn: "arn:aws:iam::123456789012:user/FakeUser2",
-            #   domain_name: "example2.com"
             }
           ]
         }
@@ -46,7 +42,7 @@ describe GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa do
       aws_client.stub_responses(
         :list_tags_for_certificate,
         {
-          tags:[
+          tags: [
             {
               key: "Name",
               value: "mycerttag1"
@@ -54,7 +50,6 @@ describe GeoEngineer::Resources::AwsAcmpcaCertificatePrivateCa do
           ]
         }
       )
-
     end
 
     it 'should create an array of hashes from the AWS response' do


### PR DESCRIPTION
ACM certificate resource to create certificates for private CA. 

AWS provides 3 options for issuing certificates, we are codifying ACM#request_certificate. 
1. Private CA issued cert 
    a) ACMPCA#issue_certificate ( Terraform does not support this at the moment)
    b) ACM#request_certificate(Private CA arn is required) (AWS managed renewal)
2. Import a Cert into ACM to be managed ACM#import_certificate
3. Amazon Issued cert ACM#request_certificate
