### PR TITLE
Add validation for security groups with bad protocol/port settings

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_security_group.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_security_group.rb
@@ -12,6 +12,14 @@ class GeoEngineer::Resources::AwsSecurityGroup < GeoEngineer::Resource
   validate -> {
     validate_subresource_required_attributes(:egress, [:from_port, :protocol, :to_port])
   }
+  validate -> {
+    all_ingress.map do |i|
+      if i.protocol.to_s == '-1' && !(i.to_port.to_s == '0' && i.from_port.to_s == '0')
+        'Cannot specify protocol of -1 with a port number other than 0 ' \
+        "(to_port = #{i.to_port} from_port = #{i.from_port})"
+      end
+    end
+  }
   validate -> { validate_has_tag(:Name) }
 
   before :validation, -> { flatten_cidr_and_sg_blocks }

--- a/spec/resources/aws_security_group_spec.rb
+++ b/spec/resources/aws_security_group_spec.rb
@@ -31,6 +31,26 @@ describe(GeoEngineer::Resources::AwsSecurityGroup) do
 
       expect(bad_cidrs.validate_correct_cidr_blocks.length).to eq 3
     end
+
+    it 'fails when protocol is -1 but ports other than 0 are specified' do
+      expect(GeoEngineer::Resources::AwsSecurityGroup.new('type', 'id') {
+        ingress {
+          protocol '-1'
+          to_port 53
+          from_port 53
+          cidr_blocks ['0.0.0.0/0']
+        }
+      }.errors.grep(/Cannot specify protocol of -1/i).size).to eq 1
+
+      expect(GeoEngineer::Resources::AwsSecurityGroup.new('type', 'id') {
+        ingress {
+          protocol '-1'
+          to_port 0
+          from_port 0
+          cidr_blocks ['0.0.0.0/0']
+        }
+      }.errors.grep(/Cannot specify protocol of -1/i).size).to eq 0
+    end
   end
 
   describe "_terraform_id and _geo_id" do


### PR DESCRIPTION
Terraform docs for `ingress.protocol` at time of writing specify:

> protocol - (Required) The protocol. If you select a protocol of "-1" (semantically equivalent to "all", which is not a valid value here), you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or "-1" use the protocol number

https://www.terraform.io/docs/providers/aws/r/security_group.html#protocol

This is confusing because Terraform itself doesn't prevent you from creating an ingress rule like:

    ingress {
      protocol -1
      to_port 53
      from_port 53
    }

It should fail in this case, but doesn't. Make our validations fail loudly instead.
