### PR TITLE
Nested block certificate_authority_configuration is a list 

### DIFF
--- a/spec/resources/aws_acmpca_spec.rb
+++ b/spec/resources/aws_acmpca_spec.rb
@@ -14,11 +14,13 @@ describe GeoEngineer::Resources::AwsAcmpcaCertificateAuthority do
         "abcbhq_dot_net"
       ) {
         type "ROOT"
-        certificate_authority_configuration {
-          subject {
-            common_name "abcbhq.net"
+        certificate_authority_configuration [
+          {
+            subject: [{
+              common_name: "abcbhq.net"
+            }]
           }
-        }
+        ]
       }
       expect(resources[:_geo_id]).to eql "ROOT::abcbhq.net"
     end


### PR DESCRIPTION
Nested blocks certificate_authority_configuration & subject are lists so they cannot be a subresources.

For context:
https://github.com/terraform-providers/terraform-provider-aws/blob/master/aws/resource_aws_acmpca_certificate_authority.go#L553
