### PR TITLE
Update the CLI to export the graph and diff command.

### DIFF
--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -220,6 +220,8 @@ class GeoCLI
     status_cmd
     test_cmd
     query_cmd
+    export_graph_command
+    diff_graph_command
   end
 
   def run
@@ -227,9 +229,6 @@ class GeoCLI
     program :version, GeoEngineer::VERSION
     program :description, 'GeoEngineer will help you Terraform your resources'
     always_trace!
-
-    # check terraform installed
-    return puts "Please install terraform" unless terraform_installed?
 
     # global_options
     global_options

--- a/lib/geoengineer/cli/terraform_commands.rb
+++ b/lib/geoengineer/cli/terraform_commands.rb
@@ -101,6 +101,9 @@ module GeoCLI::TerraformCommands
       c.description = 'Generate and show an execution plan'
       c.option '--allow-destroy', 'Run the plan with allow_destroy = true, useful for debugging'
       action = lambda do |args, options|
+        # check terraform installed
+        return puts "Please install terraform" unless terraform_installed?
+
         env.allow_destroy(true) if options.allow_destroy
         create_terraform_files
         terraform_plan
@@ -115,6 +118,9 @@ module GeoCLI::TerraformCommands
       c.option '--yes', 'Ignores the sanity check'
       c.description = 'Apply an execution plan'
       action = lambda do |args, options|
+        # check terraform installed
+        return puts "Please install terraform" unless terraform_installed?
+
         create_terraform_files
         terraform_plan
         unless options.yes || yes?("Apply the above plan? [YES/NO]")
@@ -128,11 +134,15 @@ module GeoCLI::TerraformCommands
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def destroy_cmd
     command :destroy do |c|
       c.syntax = 'geo destroy [<geo_files>]'
       c.description = 'Destroy an execution plan'
       action = lambda do |args, options|
+        # check terraform installed
+        return puts "Please install terraform" unless terraform_installed?
+
         create_terraform_files
         exit_code = terraform_plan_destroy.exitstatus
         if exit_code.nonzero?
@@ -149,4 +159,5 @@ module GeoCLI::TerraformCommands
       c.action init_action(:destroy, &action)
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
This change allows the commands to be exported without adding a .geo.rb file.