### PR TITLE
Remove monkey patching if the flag --no-mp is provided.

### DIFF
--- a/lib/geoengineer/cli/gps_commands.rb
+++ b/lib/geoengineer/cli/gps_commands.rb
@@ -49,6 +49,7 @@ module GeoCLI::GPSCommands
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def query_cmd
     command :query do |c|
       c.syntax = './geo query <query> --attributes ATTRIBUTES --expanded'
@@ -57,7 +58,7 @@ module GeoCLI::GPSCommands
       c.option '--expanded', 'If true, display the attributes with defaults inserted'
       c.option '--out PATH', String, 'File path to store output'
 
-      c.action do |args, options|
+      c.action pre_steps do |args, options|
         options.default({ environment: "development", expanded: false })
         require_environment(options)
 
@@ -75,6 +76,7 @@ module GeoCLI::GPSCommands
       end
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/MethodLength
   def export_graph_command
@@ -110,7 +112,7 @@ module GeoCLI::GPSCommands
       c.option '--stdout', 'Prints output to terminal instead of writing to graph.json'
       c.option '--file FILENAME', String, 'Exports the file to the given path instead of graph.json'
 
-      c.action do |args, options|
+      c.action pre_steps do |args, options|
         # We have to stub commands because gps/nodes/postgres.rb tests for new resources in setup
         GeoCLI::TestCmdStubs.stub!
         options.default({ stdout: false, file: './graph.json' })
@@ -127,6 +129,7 @@ module GeoCLI::GPSCommands
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def diff_graph_command
     command :'diff-graph' do |c|
       c.syntax = './geo diff-graph FILE1 FILE2'
@@ -154,7 +157,7 @@ module GeoCLI::GPSCommands
       c.option '--stdout', 'Prints output to terminal instead of writing to diff.json'
       c.option '--file FILENAME', String, 'Exports the file to the given path instead of diff.json'
 
-      c.action do |args, options|
+      c.action pre_steps do |args, options|
         options.default({ stdout: false, file: './diff.json' })
         diff = GeoEngineer::GPS::GraphUtils.difference(
           GeoEngineer::GPS::GraphUtils.flatten(JSON.parse(File.read(args[0]))),
@@ -170,5 +173,6 @@ module GeoCLI::GPSCommands
       end
     end
   end
+  # rubocop:enable Metrics/AbcSize
   # rubocop:enable Metrics/MethodLength
 end

--- a/lib/geoengineer/cli/status_command.rb
+++ b/lib/geoengineer/cli/status_command.rb
@@ -78,7 +78,7 @@ module GeoCLI::StatusCommand
   end
 
   def status_action
-    lambda do |args, options|
+    pre_steps do |args, options|
       type_stats = type_stats(options)
       status = calculate_status(type_stats)
       status = report_json(type_stats, status)

--- a/lib/geoengineer/cli/terraform_commands.rb
+++ b/lib/geoengineer/cli/terraform_commands.rb
@@ -88,7 +88,7 @@ module GeoCLI::TerraformCommands
     command :test do |c|
       c.syntax = 'geo test [<geo_files>]'
       c.description = 'Generates files while mocking AWS (useful for testing/debugging)'
-      action = lambda do |args, options|
+      action = pre_steps do |args, options|
         create_terraform_files(false)
       end
       c.action ->(args, options) { GeoCLI::TestCmdStubs.stub! && init_action(:plan, &action).call(args, options) }
@@ -100,10 +100,7 @@ module GeoCLI::TerraformCommands
       c.syntax = 'geo plan [<geo_files>]'
       c.description = 'Generate and show an execution plan'
       c.option '--allow-destroy', 'Run the plan with allow_destroy = true, useful for debugging'
-      action = lambda do |args, options|
-        # check terraform installed
-        return puts "Please install terraform" unless terraform_installed?
-
+      action = pre_steps do |args, options|
         env.allow_destroy(true) if options.allow_destroy
         create_terraform_files
         terraform_plan
@@ -117,10 +114,7 @@ module GeoCLI::TerraformCommands
       c.syntax = 'geo apply [<geo_files>]'
       c.option '--yes', 'Ignores the sanity check'
       c.description = 'Apply an execution plan'
-      action = lambda do |args, options|
-        # check terraform installed
-        return puts "Please install terraform" unless terraform_installed?
-
+      action = pre_steps do |args, options|
         create_terraform_files
         terraform_plan
         unless options.yes || yes?("Apply the above plan? [YES/NO]")
@@ -134,15 +128,11 @@ module GeoCLI::TerraformCommands
     end
   end
 
-  # rubocop:disable Metrics/AbcSize
   def destroy_cmd
     command :destroy do |c|
       c.syntax = 'geo destroy [<geo_files>]'
       c.description = 'Destroy an execution plan'
-      action = lambda do |args, options|
-        # check terraform installed
-        return puts "Please install terraform" unless terraform_installed?
-
+      action = pre_steps do |args, options|
         create_terraform_files
         exit_code = terraform_plan_destroy.exitstatus
         if exit_code.nonzero?
@@ -159,5 +149,4 @@ module GeoCLI::TerraformCommands
       c.action init_action(:destroy, &action)
     end
   end
-  # rubocop:enable Metrics/AbcSize
 end


### PR DESCRIPTION
This allows us to prevent code from being injected by .geo.rb.

Similarly, move the terraform requirement into a global option.