### PR TITLE
Add support for wildcard constants

### DIFF
--- a/lib/geoengineer/gps/constants.rb
+++ b/lib/geoengineer/gps/constants.rb
@@ -25,6 +25,12 @@ class GeoEngineer::GPS::Constants
 
   # look up in environment then look in the _global
   def dereference(environment, attribute)
+    if environment == "*"
+      return constants.map do |specific_environment, _|
+        dereference(specific_environment, attribute)
+      end.compact
+    end
+
     from_current_env = constants.dig(environment, attribute)
     return from_current_env unless from_current_env.nil?
 

--- a/spec/gps/constants_spec.rb
+++ b/spec/gps/constants_spec.rb
@@ -34,6 +34,11 @@ describe GeoEngineer::GPS::Constants do
       expect(c.dereference("e", "truthy?")).to eq true
       expect(c.dereference("e", "falsey?")).to eq false
     end
+
+    it 'works with wildcards' do
+      c = GeoEngineer::GPS::Constants.new({ "a": { "foo": 1 }, "b": { "foo": 2 } })
+      expect(c.dereference("*", "foo")).to eq [1, 2]
+    end
   end
 
   context 'yamltags' do


### PR DESCRIPTION
This supports "!ref constant:*:account_id". 
This is useful for building a list across common constants across many environments. For example, you might want to get all cidr blocks across all environments.