### PR TITLE
Adds ability to use _default as a special environment keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ development:
         ports: "80:80"
 ```
 
+If you have multiple environments and wish something to be applied to all of them evenly, you can use `_default` as a special environment keyword. This will be applied to all known environments, unless they are already defined. For example, if you had a project that was deployed to all environments except one named `internal`, you could use the following example:
+
+```yml
+_default:
+  common:
+    service:
+      api:
+        ports: "80:80"
+internal: {}
+```
+
 The `service` node type is defined to take a string of ports and build a Load balancer:
 
 ```ruby

--- a/lib/geoengineer/gps/gps.rb
+++ b/lib/geoengineer/gps/gps.rb
@@ -156,6 +156,20 @@ class GeoEngineer::GPS
 
   def loop_projects_hash(projects_hash, &block)
     projects_hash.each_pair do |project, environments|
+      # If the environments includes _default, pull out its value, and loop over
+      # all other known environments and add it back in, if it doesn't already
+      # exist. This allows _default to be used as a template for cookie cutter
+      # definitions.
+      if environments.key?("_default")
+        defenv = environments.delete("_default")
+
+        # NOTE: the constants appeared to be the best place to easily get all known environments.
+        all_environments = @constants.constants.keys.reject { |env| env.start_with?('_') }
+        all_environments.each do |env|
+          environments[env] = HashUtils.deep_dup(defenv) unless environments[env]
+        end
+      end
+
       environments.each_pair do |environment, configurations|
         configurations.each_pair do |configuration, nodes|
           loop_nodes(project, environment, configuration, nodes, &block)

--- a/lib/geoengineer/utils/hash_utils.rb
+++ b/lib/geoengineer/utils/hash_utils.rb
@@ -1,12 +1,18 @@
 # HashUtils class for helper methods
 class HashUtils
+  ALLOWED_UNDERSCORE_KEYWORDS = %w[_default].freeze
+
   def self.remove_(hash)
     hash = hash.dup
     hash.each_pair do |key, value|
-      hash.delete(key) && next if key.to_s.start_with?("_")
+      hash.delete(key) && next if key_filtered?(key)
       hash[key] = remove_(value) if value.is_a?(Hash)
     end
     hash
+  end
+
+  def self.key_filtered?(key)
+    key.to_s.start_with?("_") && !ALLOWED_UNDERSCORE_KEYWORDS.include?(key.to_s)
   end
 
   def self.json_dup(object)

--- a/spec/gps/gps_spec.rb
+++ b/spec/gps/gps_spec.rb
@@ -45,6 +45,50 @@ describe GeoEngineer::GPS do
     end
   end
 
+  describe '#loop_projects_hash' do
+    it 'should build a hash of node objects' do
+      h = { "p1" => { "e1" => { "c1" => { "test_node" => { "n1" => {} } } } } }
+      c = GeoEngineer::GPS::Constants.new({ "e1" => {}, "e2" => {} })
+      g = GeoEngineer::GPS.new(h, c)
+
+      # expect the returned hash to match the inputted hash
+      expanded_hash = g.loop_projects_hash(h) {}
+      expect(expanded_hash).to eq(h)
+    end
+
+    it 'should expand _default environment keyword to all known environments' do
+      h = { "p1" => { "_default" => { "c1" => { "test_node" => { "n1" => {} } } } } }
+      c = GeoEngineer::GPS::Constants.new({ "e1" => {}, "e2" => {} })
+      g = GeoEngineer::GPS.new(h, c)
+
+      # expect the returned hash to include the project in all environments (e1, e2)
+      eh = { "p1" => {
+        "e1" => { "c1" => { "test_node" => { "n1" => {} } } },
+        "e2" => { "c1" => { "test_node" => { "n1" => {} } } }
+      } }
+      expanded_hash = g.loop_projects_hash(h) {}
+      expect(expanded_hash).to eq(eh)
+    end
+
+    it 'should expand _default environment except ones already specified' do
+      h = { "p1" => {
+        "_default" => { "c1" => { "test_node" => { "n1" => {} } } },
+        "e2" => { "c2" => { "test_node" => { "n2" => {} } } }
+      } }
+      c = GeoEngineer::GPS::Constants.new({ "e1" => {}, "e2" => {} })
+      g = GeoEngineer::GPS.new(h, c)
+
+      # expect the returned hash to include the project in all environments (e1,
+      # e2), but they shouldn't match each other.
+      eh = { "p1" => {
+        "e1" => { "c1" => { "test_node" => { "n1" => {} } } },
+        "e2" => { "c2" => { "test_node" => { "n2" => {} } } }
+      } }
+      expanded_hash = g.loop_projects_hash(h) {}
+      expect(expanded_hash).to eq(eh)
+    end
+  end
+
   describe '#find' do
     it 'proxies the request to the finder' do
       h = { "org/p1" => { "e1" => { "c1" => { "test_node" => { "n1" => { "name" => "asd" } } } } } }


### PR DESCRIPTION
This adds the ability to use `_default` as a special keyword for the environment
name so the block defined will be used as a template for all other known
environments, except if already defined.

This can be useful when a configuration has to be applied to all
environments. Rather than having to copy and paste an entry for each
environment, it can be defined once. YAML templating can be useful to minimize
how much is copied, but it becomes tedious as the list of environments grows.

Using _default allows the project to shift from being inclusionary to being
exclusionary. If the resources should exist in most environments, but not all,
and the list of ones to not is fairly static, you can exclude the configuration
from that environment just by defining an empty hash for that environment.

For instance, to exclude a node from a `not-here` environment:

```
_default:
  production:
    test_node:
      name: n1
not-here: {}
```

Ordering doesn't matter, so the blank hash can be either before or after the
_default block.