### PR TITLE
[deps] bump netaddr version

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ class GeoEngineer::Resources::AwsSecurityGroup < GeoEngineer::Resource
       next unless in_eg.cidr_blocks
       in_eg.cidr_blocks.each do |cidr|
         begin
-          NetAddr::CIDR.create(cidr)
+          NetAddr::IPv4Net.parse(cidr)
         rescue NetAddr::ValidationError
           errors << "Bad cidr block \"#{cidr}\" #{for_resource}"
         end

--- a/geoengineer.gemspec
+++ b/geoengineer.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yard", '~> 0.9'
   s.add_development_dependency "pry-byebug", '~> 3.4'
 
-  s.add_dependency 'netaddr',           '~> 1.5'
+  s.add_dependency 'netaddr',           '~> 2.0.4'
   s.add_dependency 'aws-sdk',           '~> 3'
   s.add_dependency 'commander',         '~> 4.4'
   s.add_dependency 'colorize',          '~> 0.7'

--- a/lib/geoengineer/resources/aws/vpc/aws_vpc_ipv4_cidr_block_association.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_vpc_ipv4_cidr_block_association.rb
@@ -21,12 +21,28 @@ class GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation < GeoEngineer::Reso
   end
 
   def cidr(range)
-    NetAddr::CIDR.create(range)
+    NetAddr::IPv4Net.parse(range)
   end
 
   def range_size(errors, additional_cidr)
     msg = "The allowed block size is between a /28 netmask and /16 netmask."
-    errors << err_msg(msg) if additional_cidr.bits < 16 || additional_cidr.bits > 28
+    errors << err_msg(msg) unless additional_cidr.netmask.prefix_len.between?(16, 28)
+  end
+
+  def is_a_subnet_or_equal(ipv4net_source, ipv4net_dest)
+    # https://www.rubydoc.info/gems/netaddr/NetAddr%2FIPv4Net:rel
+    # irb(main):002:0> slash_15 = NetAddr::IPv4Net.parse('10.0.0.0/15')
+    # => #<NetAddr::IPv4Net:0x00007fc150a82dc0 @m32=#<NetAddr::Mask32:0x00007fc150a82fc8 @prefix_len=15, @mask=4294836224>, @base=#<NetAddr::IPv4:0x00007fc150a82d98 @addr=167772160>>
+    # irb(main):003:0> slash_16 = NetAddr::IPv4Net.parse('10.0.0.0/16')
+    # => #<NetAddr::IPv4Net:0x00007fc151b902e8 @m32=#<NetAddr::Mask32:0x00007fc151b90630 @prefix_len=16, @mask=4294901760>, @base=#<NetAddr::IPv4:0x00007fc151b902c0 @addr=167772160>>
+    # irb(main):004:0> slash_15.rel(slash_16)
+    # => 1
+    # irb(main):005:0> slash_16.rel(slash_15)
+    # => -1
+    if ipv4net_source.rel(ipv4net_dest) === 0 || ipv4net_source.rel(ipv4net_dest) === 1
+      return true
+    end
+    return false
   end
 
   def single_restricted_range(errors, primary_cidr, additional_cidr)
@@ -34,10 +50,10 @@ class GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation < GeoEngineer::Reso
                          cidr("172.16.0.0/12"),
                          cidr("192.168.0.0/16"),
                          cidr("198.19.0.0/16")]
-    remaining_restricted_ranges = restricted_ranges.reject { |r| r.contains?(primary_cidr) }
+    remaining_restricted_ranges = restricted_ranges.reject { |r| is_a_subnet_or_equal(r, primary_cidr) }
 
     remaining_restricted_ranges.each do |r|
-      if r.contains?(additional_cidr)
+      if is_a_subnet_or_equal(r, additional_cidr)
         errors << err_msg("Primary VPC range [#{primary_cidr}] Cannot add additional CIDR blocks from the restricted "\
           "ranges [ #{remaining_restricted_ranges.join(', ')} ]")
       end
@@ -46,15 +62,15 @@ class GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation < GeoEngineer::Reso
 
   def no_overlap(errors, primary_cidr, additional_cidr)
     msg = "The additional CIDR cannot overlap the primary VPC range"
-    errors << err_msg(msg) if primary_cidr.contains?(additional_cidr)
+    errors << err_msg(msg) if is_a_subnet_or_equal(primary_cidr, additional_cidr)
   end
 
   def special_ranges(errors, primary_cidr, additional_cidr)
-    rule1 = cidr("10.0.0.0/15").contains?(primary_cidr) && cidr("10.0.0.0/16").contains?(additional_cidr)
+    rule1 = is_a_subnet_or_equal(cidr("10.0.0.0/15"), primary_cidr) && is_a_subnet_or_equal(cidr("10.0.0.0/16"), additional_cidr)
     msg1 = "primary CIDR in 10.0.0.0/15. cannot add a CIDR block from the 10.0.0.0/16 range."
     errors << err_msg(msg1) if rule1
 
-    rule2 = cidr("172.16.0.0/12").contains?(primary_cidr) && cidr("172.31.0.0/16").contains?(additional_cidr)
+    rule2 = is_a_subnet_or_equal(cidr("172.16.0.0/12"), primary_cidr) && is_a_subnet_or_equal(cidr("172.31.0.0/16"), additional_cidr)
     msg2 = "primary CIDR in 172.16.0.0/12. cannot add a CIDR block from the 172.31.0.0/16 range"
     errors << err_msg(msg2) if rule2
   end
@@ -77,7 +93,7 @@ class GeoEngineer::Resources::AwsVpcIpv4CidrBlockAssociation < GeoEngineer::Reso
 
     no_overlap(errors, primary_cidr, additional_cidr)
 
-    return errors if cidr("100.64.0.0/10").contains?(additional_cidr)
+    return errors if is_a_subnet_or_equal(cidr("100.64.0.0/10"), additional_cidr)
 
     single_restricted_range(errors, primary_cidr, additional_cidr)
 

--- a/lib/geoengineer/utils/has_validations.rb
+++ b/lib/geoengineer/utils/has_validations.rb
@@ -52,7 +52,7 @@ module HasValidations
   # Returns error when argument fails validation
   def validate_cidr_block(cidr_block)
     return "Empty cidr block" if cidr_block.nil? || cidr_block.empty?
-    return if NetAddr::CIDR.create(cidr_block)
+    return if NetAddr::IPv4Net.parse(cidr_block)
   rescue NetAddr::ValidationError
     return "Bad cidr block \"#{cidr_block}\" #{for_resource}"
   end


### PR DESCRIPTION
Bumps `netaddr` to address CVE-2019-17383.
Required various changes to support moving from v1 to v2.

* Documented - happy to add more if helpful.
* Old function names no longer exist - hence the migration.