### PR TITLE
Adding support for Terraform state file remote backends

### DIFF
--- a/lib/geoengineer/backend.rb
+++ b/lib/geoengineer/backend.rb
@@ -1,0 +1,43 @@
+########################################################################
+# Outputs are mapped 1:1 to terraform outputs
+#
+# {https://www.terraform.io/docs/backends Terraform Docs}
+########################################################################
+class GeoEngineer::Backend
+  attr_reader :id
+  include HasAttributes
+  include HasSubResources
+
+  def initialize(id, &block)
+    @id = id
+    instance_exec(self, &block) if block_given?
+  end
+
+  def terraform_id
+    if self.alias
+      "#{id}.#{self.alias}"
+    else
+      id
+    end
+  end
+
+  ## Terraform methods
+  def to_terraform
+    sb = ["backend #{@id.inspect} { "]
+
+    sb.concat(terraform_attributes.map { |k, v| "  #{k.to_s.inspect} = #{v.inspect}" })
+
+    sb.concat subresources.map(&:to_terraform)
+    sb << " }"
+    sb.join("\n")
+  end
+
+  def to_terraform_json
+    json = terraform_attributes
+    subresources.map(&:to_terraform_json).each do |k, v|
+      json[k] ||= []
+      json[k] << v
+    end
+    { id.to_s => json }
+  end
+end

--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -54,14 +54,14 @@ class GeoCLI
     end
   end
 
-  def create_environment(name, &block)
+  def create_environment(name, remote_state = false, &block)
     return @environment if @environment
     if name != @env_name
       puts "Not loading environment #{name} as env_name is #{@env_name}" if @verbose
       return NullObject.new
     end
 
-    @environment = GeoEngineer::Environment.new(name, &block)
+    @environment = GeoEngineer::Environment.new(name, remote_state, &block)
     init_tmp_dir(name)
     init_terraform_files()
     @environment

--- a/lib/geoengineer/cli/globals.rb
+++ b/lib/geoengineer/cli/globals.rb
@@ -2,8 +2,8 @@
 # It should not be included in the library
 require_relative './geo_cli'
 
-def environment(name, &block)
-  GeoCLI.instance.create_environment(name, &block)
+def environment(name, remote_state = false, &block)
+  GeoCLI.instance.create_environment(name, remote_state, &block)
 end
 
 def env


### PR DESCRIPTION
Terraform supports storing and fetching state files from a remote location for the purposes of caching, security, and collaboration. GeoEngineer historically has not fetched a remotely shared state file, however in order to support better integration with Terraform, GeoEngineer will now support remote backends (https://www.terraform.io/docs/backends/index.html)

This PR adds the ability to configure a remote backend, which is bootstrapped when "terraform init" is called.