### PR TITLE
Update IAM role policy attach to handle ARN not existing and TF ref

### DIFF
--- a/spec/resources/aws_iam_role_policy_attachment_spec.rb
+++ b/spec/resources/aws_iam_role_policy_attachment_spec.rb
@@ -50,4 +50,71 @@ describe GeoEngineer::Resources::AwsIamRolePolicyAttachment do
       )
     end
   end
+
+  describe '#remote_resource_params' do
+    before do
+      aws_client.stub_responses(
+        :list_policies,
+        {
+          policies: [
+            {
+              arn: 'arn:aws:iam::aws:policy/xyv/FakeAwsARN',
+              policy_name: 'Fake-Aws-Policy'
+            }
+          ]
+        }
+      )
+
+      aws_client.stub_responses(
+        :list_entities_for_policy,
+        {
+          policy_users:  [
+            { user_name: 'fake-user' },
+            { user_name: 'fake-user-2' }
+          ],
+          policy_groups: [
+            { group_name: 'fake-group' }
+          ],
+          policy_roles: [
+            { role_name: 'fake-role' }
+          ]
+        }
+      )
+    end
+
+    it 'returns valid IDs for policies that exist' do
+      pa = GeoEngineer::Resources::AwsIamRolePolicyAttachment.new('aws_iam_role_policy_attachment', 'fake_policy_attachment') {
+        role 'fake-role'
+        policy_arn 'arn:aws:iam::aws:policy/xyv/FakeAwsARN'
+      }
+
+      params = pa.remote_resource_params
+      expect(params[:_terraform_id]).to eq "fake-role/arn:aws:iam::aws:policy/xyv/FakeAwsARN"
+      expect(params[:_geo_id]).to eq "fake-role:arn:aws:iam::aws:policy/xyv/FakeAwsARN"
+    end
+
+    it 'returns nothing for Policy ARNs which do not exist yet' do
+      aws_client.stub_responses(
+        :list_entities_for_policy, 'NoSuchEntity'
+      )
+
+      pa = GeoEngineer::Resources::AwsIamRolePolicyAttachment.new('aws_iam_role_policy_attachment', 'fake_policy_attachment') {
+        role 'fake-role'
+        policy_arn 'arn:aws:iam::aws:policy/xyv/NewAwsARN'
+      }
+
+      params = pa.remote_resource_params
+      expect(params).to eq({})
+    end
+
+    it 'returns nothing for Policy ARNs which are Terraform references' do
+      pa = GeoEngineer::Resources::AwsIamRolePolicyAttachment.new('aws_iam_role_policy_attachment', 'fake_policy_attachment') {
+        role 'fake-role'
+        policy_arn '${aws_iam_policy.my_awesome_new_policy.arn}'
+      }
+
+      params = pa.remote_resource_params
+      expect(params).to eq({})
+    end
+  end
 end


### PR DESCRIPTION
This updates the `aws_iam_role_policy_attachment` handling to better support two
cases.

First, when to not error when the given policy ARN doesn't exist. This makes it
so Geoengineer won't error, but Terraform later will. The primary case is that
you might be creating the policy and the role attachment in the same run. Even
when adding the depends_on, Geoengineer would error out before it expects it to
already exist.

Second, it updates it to skip fetching when the policy ARN is formatted like a
Terraform reference. This also can happen in cases where creating the policy and
the attachment in the same run, or when populating the ARN with a reference
instead of hard setting the value.

This primarily benefits bootstrapping new things where common base resources are
created, like policies, and attaching them to individual items, all in the same
run.