### PR TITLE
Prevent running partial applies or plans when remote state enabled

### DIFF
--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -115,7 +115,8 @@ class GeoCLI
     # if remote state files are supported, all project files must be used
     # otherwise terraform will assume resources should be deleted.
     if env.remote_state_supported? && !files.empty?
-      throw "This environment is configured to use remote Terraform state files, which requires loading all project files. Re-run the geo command with no arguments."
+      throw "This environment is configured to use remote Terraform state files, which requires loading all project files.
+             Re-run the geo command with no arguments."
     end
     # load everything if empty
     return require_all_projects if files.empty?

--- a/lib/geoengineer/cli/geo_cli.rb
+++ b/lib/geoengineer/cli/geo_cli.rb
@@ -112,6 +112,11 @@ class GeoCLI
 
   # this method accepts .rb files and .gps.yml files
   def require_geo_files(files)
+    # if remote state files are supported, all project files must be used
+    # otherwise terraform will assume resources should be deleted.
+    if env.remote_state_supported? && !files.empty?
+      throw "This environment is configured to use remote Terraform state files, which requires loading all project files. Re-run the geo command with no arguments."
+    end
     # load everything if empty
     return require_all_projects if files.empty?
 


### PR DESCRIPTION
If the remote state file backend is enabled, applies and plans run with a path to .rb or .gps.yml configuration files will cause terraform to propose resource deletions. This is because it believes configuration files have been deleted.

The code changes in this PR raise an exception if remote state files are supported in an environment and gps or rb files are provided in the geo cli command.