### PR TITLE
Update aws_internet_gateway to match remote resources on the VPC id

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_internet_gateway.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_internet_gateway.rb
@@ -8,7 +8,7 @@ class GeoEngineer::Resources::AwsInternetGateway < GeoEngineer::Resource
   validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { NullObject.maybe(tags)[:Name] } }
+  after :initialize, -> { _geo_id -> { vpc_id } }
 
   def self._fetch_remote_resources(provider)
     AwsClients.ec2(provider)
@@ -16,7 +16,7 @@ class GeoEngineer::Resources::AwsInternetGateway < GeoEngineer::Resource
       gateway.merge(
         {
           _terraform_id: gateway[:internet_gateway_id],
-          _geo_id: gateway[:tags]&.find { |tag| tag[:key] == "Name" }&.dig(:value)
+          _geo_id: gateway.dig(:attachments)&.find { |a| !a[:vpc_id].nil? }&.dig(:vpc_id)
         }
       )
     end

--- a/spec/resources/aws_internet_gateway_spec.rb
+++ b/spec/resources/aws_internet_gateway_spec.rb
@@ -2,7 +2,6 @@ require_relative '../spec_helper'
 
 describe(GeoEngineer::Resources::AwsInternetGateway) do
   common_resource_tests(described_class, described_class.type_from_class_name)
-  name_tag_geo_id_tests(GeoEngineer::Resources::AwsInternetGateway)
 
   describe "#_fetch_remote_resources" do
     it 'should create list of hashes from returned AWS SDK' do
@@ -11,8 +10,8 @@ describe(GeoEngineer::Resources::AwsInternetGateway) do
         :describe_internet_gateways,
         {
           internet_gateways: [
-            { internet_gateway_id: 'name1', tags: [{ key: 'Name', value: 'one' }] },
-            { internet_gateway_id: 'name2', tags: [{ key: 'Name', value: 'two' }] }
+            { internet_gateway_id: 'name1', tags: [{ key: 'Name', value: 'one' }], attachments: [{ vpc_id: 'vpc-123' }] },
+            { internet_gateway_id: 'name2', tags: [{ key: 'Name', value: 'two' }], attachments: [{ vpc_id: 'vpc-456' }] }
           ]
         }
       )


### PR DESCRIPTION
This changes the aws_internet_gateway resources to match the remote resource
based on the vpc_id rather than the Name tag.

This is done because vpc_id is a required attribute, so it is always present,
and a VPC can only have 1 internet gateway attached to it at a time. This will
allow simple matching and better handle things like changing naming patterns in
name tags.

If the gateway is detached, or it is created but not attached in a run, it will
result in provisioning a new one, however there is no harm in that because
there is not specialized configuration for them. If one is removed, then it
would also be removed from all route tables, so there would be no conflict in
provisioning a new one to attach.