### PR TITLE
Silence force_destroy updates for aws_s3_bucket_object

### DIFF
--- a/lib/geoengineer/resources/aws/s3/aws_s3_bucket_object.rb
+++ b/lib/geoengineer/resources/aws/s3/aws_s3_bucket_object.rb
@@ -19,6 +19,9 @@ class GeoEngineer::Resources::AwsS3BucketObject < GeoEngineer::Resource
       'content'      => remote_resource.content,
       'content_type' => remote_resource.content_type
     }
+
+    tfstate[:primary][:attributes]['force_destroy'] =
+      force_destroy.nil? || force_destroy == '' ? 'false' : force_destroy
     tfstate
   end
 


### PR DESCRIPTION
A recent upgrade of the AWS provisioner seems to have resulted in unnecessary changes appearing for `aws_s3_bucket_object` resources.

Fix these by interpreting an empty string for force_destroy as 'false'.

This eliminates spurious plans like:

    ~ aws_s3_bucket_object.my_bucket_object
        force_destroy:   "" => "false"
