### PR TITLE
[FIX] Allow CloudHsm Resources to plan correctly

### DIFF
--- a/lib/geoengineer/resources/aws/cloudhsm/aws_cloudhsm_v2_hsm.rb
+++ b/lib/geoengineer/resources/aws/cloudhsm/aws_cloudhsm_v2_hsm.rb
@@ -7,20 +7,10 @@ class GeoEngineer::Resources::AwsCloudhsmV2Hsm < GeoEngineer::Resource
   validate -> { validate_required_attributes([:subnet_id]) }
   validate -> { validate_at_least_one_present([:_cluster, :cluster_id]) }
 
-  before :validation, -> { cluster_id _cluster.to_ref(:id) if _cluster && !cluster_id }
-  before :validation, -> { _cluster_name _cluster.tags[:Name] if _cluster && !cluster_id }
-
+  after :initialize, -> { cluster_id -> { self._cluster.to_ref(:id) if self._cluster } }
+  after :initialize, -> { _cluster_name -> { self._cluster.tags[:Name] if self._cluster } }
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{self._cluster_name || self.cluster_id}_#{self.subnet_id}" } }
-
-  # def to_terraform_state
-  #   tfstate = super
-
-  #   attributes['cluster_id'] = remote_resource[:cluster_id] if remote_resource
-
-  #   tfstate[:primary][:attributes] = attributes
-  #   tfstate
-  # end
 
   def self._fetch_remote_resources(provider)
     client = AwsClients.cloudhsm(provider)


### PR DESCRIPTION
Before, the `_geo_id` was not being set properly, so Geo would try to
recreate the HSM on every plan.

This change fixes that, ensuring the `_geo_id` is set properly.

This was tested out by monkey patching the code in aws-resources and
testing with a `./geo plan` against existing resources.