### PR TITLE
WIP: Update workflow for expanding meta nodes around create_resources

### DIFF
--- a/lib/geoengineer/gps/node.rb
+++ b/lib/geoengineer/gps/node.rb
@@ -144,6 +144,7 @@ class GeoEngineer::GPS::Node
     id_lambda = -> { resource_id(name) } if id_lambda.nil?
     read_method = name.to_s
     ref_method = "#{name}_ref"
+    tf_method = "#{name}_terraform_name"
     create_method = "create_#{name}"
 
     define_method(read_method) do
@@ -155,6 +156,12 @@ class GeoEngineer::GPS::Node
       instance_exec(&load_gps_file) if auto_load
       id = instance_exec(&id_lambda)
       "${#{type}.#{id}.#{attribute}}"
+    end
+
+    define_method(tf_method) do |auto_load = true|
+      instance_exec(&load_gps_file) if auto_load
+      id = instance_exec(&id_lambda)
+      "#{type}.#{id}"
     end
 
     define_method(create_method) do |project|


### PR DESCRIPTION
This changes some of the logic for building nodes on meta nodes. An issue that
was found was around cases of circular references, where projectA refers to
projectB and projectB refers to projectA. If projectA includes MetaNodes, it
will have `create_resources` called on its resources before `build_nodes` is
called on its meta nodes.

In this case, `build_nodes` is eventually called, but since resources were
already created, they won't be called again. As such, the expanded GPS tree
shows the child nodes, however their base Geoengineer resources are never
processed, so it doesn't show in the Terraform state. This is because in gps.rb
`partial_of`, it won't go into `create_project` if it has already been called.

This changes it so that expanding meta nodes is not within the `nodes` helper
and instead is more explicitly done within
`create_all_resource_for_project`. This way, it will expand the nodes shortly
before it calls `create_resources` on all of the resources, including the
expanded ones.

Circular dependencies are still possible, but may need some more specific care
around using things like `gps.find`. Previously, with a circular dependency, the
call from projectB to projectA would force creating resources on everything in
projectA (at least, everything it had). With this change, when projectB calls to
projectA, projectA will still be mid way through creating its resources. Its
node objects will exist, but might not have had `create_resources` called on
them yet.

Doing `gps.dereference!` isn't an issue, since that is just accessing
attributes. Only impacts `gps.find` or `gps.where`, which returns the actual
nodes. Main issue is you were doing `node.policy.terraform_name` or
`node.policy.to_id_or_ref`.

To mitigate that, you can simply use `node.policy_ref` or use `-> {
node.policy.to_id_or_ref }`, where the attribute is set to a lambda. For cases
like using `.terraform_name`, the `define_resource` function for GPS nodes now
creates a `resource_terraform_name` helper function, similar to the
`resource_ref` one.

This case of creating resources is not an issue with non-circular
dependencies.

TBD: Testing.