### PR TITLE
Adds a set of tests for circular dependencies in GPS

### DIFF
--- a/spec/gps/examples/projects/org/p1.gps.yml
+++ b/spec/gps/examples/projects/org/p1.gps.yml
@@ -1,0 +1,5 @@
+e1:
+  c1:
+    test_circular_meta:
+      n1:
+        child_resource: org/p2:::test_circular_node:n2#elb

--- a/spec/gps/examples/projects/org/p2.gps.yml
+++ b/spec/gps/examples/projects/org/p2.gps.yml
@@ -1,0 +1,5 @@
+e1:
+  c1:
+    test_circular_node:
+      n2:
+        child_resource: org/p1:e1:c1:test_node:n1#elb

--- a/spec/gps/examples/projects/org/p3.rb
+++ b/spec/gps/examples/projects/org/p3.rb
@@ -1,0 +1,1 @@
+GeoCLI.instance.gps.find("org/p1:e1:c1:test_circular_meta:n1")

--- a/spec/gps/test_nodes.rb
+++ b/spec/gps/test_nodes.rb
@@ -72,3 +72,53 @@ class GeoEngineer::GPS::Nodes::TestMetaMetaNode < GeoEngineer::GPS::MetaNode
     }
   end
 end
+
+class GeoEngineer::GPS::Nodes::TestCircularMeta < GeoEngineer::GPS::Nodes::TestMetaNode
+  attr_reader :child_resource
+
+  def json_schema
+    {
+      "type":  "object",
+      "additionalProperties" => false,
+      "properties":  {
+        "name":  {
+          "type":  "string",
+          "default":  "default"
+        },
+        "child_resource": {
+          "type": "string"
+        }
+      }
+    }
+  end
+
+  def build_nodes
+    @child_resource = finder.dereference!(attributes["child_resource"])
+    super
+  end
+end
+
+class GeoEngineer::GPS::Nodes::TestCircularNode < GeoEngineer::GPS::Nodes::TestNode
+  attr_reader :child_resource
+
+  def json_schema
+    {
+      "type":  "object",
+      "additionalProperties" => false,
+      "properties":  {
+        "name":  {
+          "type":  "string",
+          "default":  "default"
+        },
+        "child_resource": {
+          "type": "string"
+        }
+      }
+    }
+  end
+
+  def create_resources(project)
+    @child_resource = finder.dereference!(attributes["child_resource"])
+    super(project)
+  end
+end


### PR DESCRIPTION
This adds a set of tests to `gps_spec.rb`. It didn't have many tests which
covered meta nodes and references, particularly where two things reference each
other.

These were tests added while investigating #389. Turns out they were passing on
master, but failing on that branch. I wasn't able to reproduce a failing test on
master for the issue it was aiming to fix, which likely means there was another
layer to the cause which wasn't reproducing correctly.

These tests would still be good to keep, especially since some of them covered
functions that weren't being covered before, like `load_gps_file` and testing
loading of files from disk.