### PR TITLE
Updates aws_vpc_endpoint to allow tags and require a name tag

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_vpc_endpoint.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_vpc_endpoint.rb
@@ -5,13 +5,10 @@
 ########################################################################
 class GeoEngineer::Resources::AwsVpcEndpoint < GeoEngineer::Resource
   validate -> { validate_required_attributes([:vpc_id, :service_name]) }
+  validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
   after :initialize, -> { _geo_id -> { "#{vpc_id}::#{service_name}" } }
-
-  def support_tags?
-    false
-  end
 
   def self._fetch_remote_resources(provider)
     AwsClients.ec2(provider).describe_vpc_endpoints['vpc_endpoints'].map(&:to_h).map do |endpoint|


### PR DESCRIPTION
This updates the `aws_vpc_endpoint` resource to enable tags and require it to
have a `Name` tag. Previously, it is likely it didn't support tags, but now it
does.

This is step 1 to including the Name tag in the geo_id so we can have multiple
endpoints per service type within a VPC. This is being done in 2 steps so we can
add Name tags to all existing resources before using it in the geo_id, as that
would want it to provision new endpoints for all existing uses.