### PR TITLE
support context in api gateway rest api _policy_file function

### DIFF
--- a/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_rest_api.rb
+++ b/lib/geoengineer/resources/aws/api_gateway/aws_api_gateway_rest_api.rb
@@ -59,8 +59,8 @@ class GeoEngineer::Resources::AwsApiGatewayRestApi < GeoEngineer::Resource
     NullObject.maybe(remote_resource).root_resource_id
   end
 
-  def _policy_file(path)
-    policy _json_file(:policy, path)
+  def _policy_file(path, binding_obj = nil)
+    _json_file(:policy, path, binding_obj)
   end
 
   def to_terraform_state


### PR DESCRIPTION
The existing _policy_file function did not allow passing in a context. This is required if template variables exist in the ERB file.