### PR TITLE
Add the Name tag as part of the geo_id for aws_vpc_endpoint

### DIFF
--- a/lib/geoengineer/resources/aws/vpc/aws_vpc_endpoint.rb
+++ b/lib/geoengineer/resources/aws/vpc/aws_vpc_endpoint.rb
@@ -8,14 +8,15 @@ class GeoEngineer::Resources::AwsVpcEndpoint < GeoEngineer::Resource
   validate -> { validate_has_tag(:Name) }
 
   after :initialize, -> { _terraform_id -> { NullObject.maybe(remote_resource)._terraform_id } }
-  after :initialize, -> { _geo_id -> { "#{vpc_id}::#{service_name}" } }
+  after :initialize, -> { _geo_id -> { "#{vpc_id}::#{service_name}::#{NullObject.maybe(tags)[:Name]}" } }
 
   def self._fetch_remote_resources(provider)
     AwsClients.ec2(provider).describe_vpc_endpoints['vpc_endpoints'].map(&:to_h).map do |endpoint|
+      tag_name = endpoint[:tags]&.find { |tag| tag[:key] == 'Name' }&.dig(:value)
       endpoint.merge(
         {
           _terraform_id: endpoint[:vpc_endpoint_id],
-          _geo_id: "#{endpoint[:vpc_id]}::#{endpoint[:service_name]}"
+          _geo_id: "#{endpoint[:vpc_id]}::#{endpoint[:service_name]}::#{tag_name}"
         }
       )
     end


### PR DESCRIPTION
This adds the Name tag to be a part of the geo_id for aws_vpc_endpoint. This
will allow us to have multiple endpoints for a single service within a VPC,
primarily for use with different subnets in the same availability zone.